### PR TITLE
chore: add initial list of TSC members

### DIFF
--- a/.github/workflows/tsc_members_validator/schema.json
+++ b/.github/workflows/tsc_members_validator/schema.json
@@ -2,6 +2,7 @@
     "$id": "root",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "array",
+    "description": "List of all TSC members and information about them.",
     "items": {
       "type": "object",
       "properties": {

--- a/.github/workflows/tsc_members_validator/schema.json
+++ b/.github/workflows/tsc_members_validator/schema.json
@@ -8,6 +8,7 @@
       "properties": {
         "name": {
           "type": "string",
+          "minLength": 1,
           "description": "Full name of the person, a nice human-readable name",
           "examples": [
             "Lukasz Gornicki"
@@ -23,6 +24,7 @@
         },
         "linkedin": {
           "type": "string",
+          "minLength": 1,
           "description": "Only LinkedIn profile name, everything you see after https://www.linkedin.com/in/ link. It is used on the AsyncAPI website to provide link to profile.",
           "examples": [
             "lukasz-gornicki-a621914"
@@ -30,6 +32,7 @@
         },
         "twitter": {
           "type": "string",
+          "minLength": 1,
           "description": "Twitter profile name. It is used on the AsyncAPI website to provide link to profile.",
           "examples": [
             "derberq"
@@ -46,6 +49,7 @@
         },
         "company": {
           "type": "string",
+          "minLength": 1,
           "description": "It must be clear if given TSC member is affiliated with some company. AsyncAPI's open governance model allows no more than 1/4 of TSC representatives from the same company. In case you are an individual contributor, you do not have to provide this property. In the UI we will mark you as individual contributor if this property is missing.",
           "examples": [
             "Postman"

--- a/.github/workflows/tsc_members_validator/schema.json
+++ b/.github/workflows/tsc_members_validator/schema.json
@@ -1,0 +1,69 @@
+{
+    "$id": "root",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "array",
+    "items": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Full name of the person, a nice human-readable name",
+          "examples": [
+            "Lukasz Gornicki"
+          ]
+        },
+        "github": {
+          "type": "string",
+          "description": "In must be a valid GitHub handle. It is used to provide a link to person's profile on GitHub and display profile picture on the AsyncAPI website",
+          "examples": [
+            "derberg"
+          ]
+        },
+        "linkedin": {
+          "type": "string",
+          "description": "Only LinkedIn profile name, everything you see after https://www.linkedin.com/in/ link. It is used on the AsyncAPI website to provide link to profile.",
+          "examples": [
+            "lukasz-gornicki-a621914"
+          ]
+        },
+        "twitter": {
+          "type": "string",
+          "description": "Twitter profile name. It is used on the AsyncAPI website to provide link to profile.",
+          "examples": [
+            "derberq"
+          ]
+        },
+        "availableForHire": {
+          "type": "boolean",
+          "description": "It is not mandatory property as by default it is set to false. Nevertheless please add it, even if 'false' for better clarity. We use it on the AsyncAPI website to visually indicate that given person is available for hire.",
+          "default": false,
+          "examples": [
+            true,
+            false
+          ]
+        },
+        "company": {
+          "type": "string",
+          "description": "It must be clear if given TSC member is affiliated with some company. AsyncAPI's open governance model allows no more than 1/4 of TSC representatives from the same company. In case you are an individual contributor, you do not have to provide this property. In the UI we will mark you as individual contributor if this property is missing.",
+          "examples": [
+            "Postman"
+          ]
+        },
+        "repos": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "List of repositories names that must match the GitHub name of the repository. It is used to provide a link to the repository in AsyncAPI website",
+            "examples": [
+              "avro-schema-parser"
+            ]
+          }
+        }
+      },
+      "required": [
+        "github",
+        "repos"
+      ],
+      "additionalProperties": false
+    }
+  }

--- a/.github/workflows/tsc_members_validator/schema.json
+++ b/.github/workflows/tsc_members_validator/schema.json
@@ -15,6 +15,7 @@
         },
         "github": {
           "type": "string",
+          "minLength": 1,
           "description": "In must be a valid GitHub handle. It is used to provide a link to person's profile on GitHub and display profile picture on the AsyncAPI website",
           "examples": [
             "derberg"
@@ -52,6 +53,7 @@
         },
         "repos": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "type": "string",
             "description": "List of repositories names that must match the GitHub name of the repository. It is used to provide a link to the repository in AsyncAPI website",

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -9,7 +9,7 @@ on:
       - 'TSC_MEMBERS.json'
 
 jobs:
-  Make-PR:
+  update-website:
     name: Make PR on website repository with updated tsc members list
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -1,0 +1,49 @@
+#This action update the list of TSC members in the website repository. List of all TSC members is later rendered in the asyncapi.com website.
+name: Update list of TSC members in the website repo
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'TSC_MEMBERS.json'
+
+jobs:
+  Make-PR:
+    name: Make PR on website repository with updated tsc members list
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    steps:
+      - name: Checkout Current repository
+        uses: actions/checkout@v2
+        with:
+          path: community
+      - name: Checkout Another repository
+        uses: actions/checkout@v2
+        with:
+          repository: asyncapi/website
+          path: website
+          token: ${{ env.GITHUB_TOKEN }}
+      - name: Config git
+        run: |
+          git config --global user.name asyncapi-bot
+          git config --global user.email info@asyncapi.io
+      - name: Create branch
+        working-directory: ./website
+        run: |
+          git checkout -b update-tscmembers-${{ github.head_ref }}
+      - name: Copy tsc members file from Current Repo to Another
+        working-directory: ./website
+        run: |
+          cp ../community/TSC_MEMBERS.json ./config/TSC_MEMBERS.json
+      - name: Commit and push
+        working-directory: ./website
+        run: |
+          git add .
+          git commit -m "docs(community): update latest tsc members list"
+          git push https://${{ env.GITHUB_TOKEN }}@github.com/asyncapi/website
+      - name: Create PR
+        working-directory: ./website
+        run: |
+          gh pr create --title "docs(community): update latest tsc members list" --body "Updated TSC members list is available and this PR introduces changes with latest information about TSC members" --head "update-tscmembers-${{ github.head_ref }}"

--- a/.github/workflows/validate-tsc-members.yml
+++ b/.github/workflows/validate-tsc-members.yml
@@ -22,7 +22,6 @@ jobs:
           script: |
             const Ajv = require("ajv");
             const fs = require('fs').promises;
-            const core = require('@actions/core');
 
             const schema = await fs.readFile('.github/workflows/tsc_members_validator/schema.json', 'utf8');
             const members = await fs.readFile('TSC_MEMBERS.json', 'utf8');

--- a/.github/workflows/validate-tsc-members.yml
+++ b/.github/workflows/validate-tsc-members.yml
@@ -3,7 +3,8 @@ name: Validating the list of technical steering committee members
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-
+    paths:
+      - 'TSC_MEMBERS.json'
 jobs:
   # make sure that changes in the TSC_MEMBERS file is not breaking the schema
   # until we have TSC_MEMBERS.json updates automated we need to make sure we are not breaking things

--- a/.github/workflows/validate-tsc-members.yml
+++ b/.github/workflows/validate-tsc-members.yml
@@ -1,0 +1,50 @@
+name: Validating the list of technical steering committee members
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  # make sure that changes in the TSC_MEMBERS file is not breaking the schema
+  # until we have TSC_MEMBERS.json updates automated we need to make sure we are not breaking things
+  validate_schema:
+    if: github.event.pull_request.draft == false
+    name: Validate JSON Schema for TSC_MEMBERS list
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: emagers/json-schema-validation@v1.0.0
+        with:
+          schema: .github/workflows/tsc_members_validator/schema.json
+          testFile: TSC_MEMBERS.json
+  
+  # open governance model doesn't allow more than 1/4 TSC members affiliated with a single company
+  calculate_companies:
+    if: github.event.pull_request.draft == false
+    name: Calculate TSC members affiliation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Calculate
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          script: |
+            const members = require('./TSC_MEMBERS.json');
+            const allMembers = members.length;
+            
+            const allowedMemberPerCompany = (allMembers/4).toFixed(0)
+            const numberOfMemByCompany = members.reduce((acc, m) => {
+              const company = m.company && m.company.toLowerCase();
+            
+              if (company) acc.has(company) ? acc.set(company,acc.get(company)+1) : acc.set(company,1);
+              return acc;
+            }, new Map())
+
+            numberOfMemByCompany.forEach((numberOfRepresentatives, companyName) => {
+              if (numberOfRepresentatives > allowedMemberPerCompany) core.error(`There are to many members affiliated with ${companyName} and it violate open governance model. ${numberOfRepresentatives} is more that 1/4 of ${allMembers}`)
+            })
+ 

--- a/.github/workflows/validate-tsc-members.yml
+++ b/.github/workflows/validate-tsc-members.yml
@@ -15,12 +15,30 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - run: npm install ajv@6.12.6
       - name: Validate list with schema
-        uses: emagers/json-schema-validation@v1.0.0
+        uses: actions/github-script@v4
         with:
-          schema: .github/workflows/tsc_members_validator/schema.json
-          testFile: TSC_MEMBERS.json
-  
+          script: |
+            const Ajv = require("ajv");
+            const fs = require('fs').promises;
+            const core = require('@actions/core');
+
+            const schema = await fs.readFile('.github/workflows/tsc_members_validator/schema.json', 'utf8');
+            const members = await fs.readFile('TSC_MEMBERS.json', 'utf8');
+            
+            const ajv = new Ajv();
+            const validator = ajv.compile(schema);
+
+            const valid = validator(members);
+
+            if (!valid) {
+              core.error(`Validation of members file failed with the following errors:`);
+              core.error(validator.errors);
+            } else {
+              core.info(`TSC members file is valid`);
+            }
+
   # open governance model doesn't allow more than 1/4 TSC members affiliated with a single company
   calculate_companies:
     if: github.event.pull_request.draft == false
@@ -32,7 +50,6 @@ jobs:
       - name: Calculate
         uses: actions/github-script@v4
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const members = require('./TSC_MEMBERS.json');
             const allMembers = members.length;

--- a/.github/workflows/validate-tsc-members.yml
+++ b/.github/workflows/validate-tsc-members.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: golangci-lint
+      - name: Validate list with schema
         uses: emagers/json-schema-validation@v1.0.0
         with:
           schema: .github/workflows/tsc_members_validator/schema.json

--- a/.github/workflows/validate-tsc-members.yml
+++ b/.github/workflows/validate-tsc-members.yml
@@ -27,9 +27,9 @@ jobs:
             const members = await fs.readFile('TSC_MEMBERS.json', 'utf8');
             
             const ajv = new Ajv();
-            const validator = ajv.compile(schema);
+            const validator = ajv.compile(JSON.parse(schema));
 
-            const valid = validator(members);
+            const valid = validator(JSON.parse(members));
 
             if (!valid) {
               core.error(`Validation of members file failed with the following errors:`);

--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -173,7 +173,7 @@
         },
         {
             "github": "NektariosFifes",
-            "availableForHire": false,
+            "availableForHire": true,
             "repos": [
                 "simulator"
             ]

--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -15,7 +15,7 @@
             "github": "arjungarg07",
             "linkedin": "arjungarg17",
             "twitter": "ArjunGarg07",
-            "availableForHire": false,
+            "availableForHire": true,
             "repos": [
                 "cupid"
             ]

--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -173,6 +173,7 @@
         },
         {
             "github": "NektariosFifes",
+            "linkedin": "nektarios-fifes-372740220",
             "availableForHire": true,
             "repos": [
                 "simulator"

--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -147,7 +147,7 @@
             "github": "Souvikns",
             "twitter": "souvik_ns",
             "linkedin": "souvik-de-a2b941169",
-            "availableForHire": false,
+            "availableForHire": true,
             "repos": [
                 "cli"
             ]

--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -155,7 +155,9 @@
             ]
         },
         {
+            "name": "Pavel Bodiachevskii",
             "github": "Pakisan",
+            "twitter": "pbodiachevskii",
             "availableForHire": false,
             "repos": [
                 "jasyncapi"

--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -84,7 +84,7 @@
             "github": "KhudaDad414",
             "twitter": "KhudaDadNomani",
             "linkedin": "khudadadnomani",
-            "availableForHire": false,
+            "availableForHire": true,
             "repos": [
                 "optimizer"
             ]
@@ -130,6 +130,7 @@
                 "generator",
                 "html-template",
                 "markdown-template",
+                "modelina",
                 "parser-js",
                 "playground",
                 "website"
@@ -138,7 +139,7 @@
         {
             "github": "AceTheCreator",
             "twitter": "_acebuild",
-            "availableForHire": false,
+            "availableForHire": true,
             "repos": [
                 "chatbot"
             ]

--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -1,178 +1,180 @@
 [
-    {
-        "name": "Aayush Sahu",
-        "github": "aayushmau5",
-        "linkedin": "aayushmau5",
-        "twitter": "aayushmau5",
-        "availableForHire": false,
-        "repos": [
-            "diff"
-        ]
-    },
-    {
-        "name": "Arjun Garg",
-        "github": "arjungarg07",
-        "linkedin": "arjungarg17",
-        "twitter": "ArjunGarg07",
-        "availableForHire": false,
-        "repos": [
-            "cupid"
-        ]
-    },
-    {
-        "name": "Emiliano Zublena",
-        "github": "emilianozublena",
-        "availableForHire": false,
-        "repos": [
-            "asyncapi-php-template"
-        ]
-    },
-    {
-        "name": "Fran Méndez",
-        "github": "fmvilas",
-        "availableForHire": false,
-        "company": "Postman",
-        "linkedin": "fmvilas",
-        "repos": [
-            "raml-dt-schema-parser",
-            "avro-schema-parser",
-            "openapi-schema-parser",
-            "asyncapi-react",
-            "glee",
-            "generator",
-            "nodejs-template",
-            "nodejs-ws-template",
-            "parser-js",
-            "playground",
-            "spec",
-            "spec-json-schemas",
-            "website",
-            "bindings"
-        ]
-    },
-    {
-        "name": "Jonas Lagoni",
-        "github": "jonaslagoni",
-        "linkedin": "jonaslagoni",
-        "availableForHire": false,
-        "company": "Postman",
-        "repos": [
-            "dotnet-nats-template",
-            "ts-nats-template",
-            "generator-react-sdk",
-            "generator",
-            "modelina",
-            "parser-js",
-            "simulator"
-        ]
-    },
-    {
-        "name": "Jorge Aguiar Martín",
-        "github": "jotamusik",
-        "linkedin": "jorge-aguiar-martin",
-        "twitter": "jotamusik",
-        "availableForHire": false,
-        "company": "LeanMind",
-        "repos": [
-            "cli"
-        ]
-    },
-    {
-        "name": "Khuda Dad Nomani",
-        "github": "KhudaDad414",
-        "twitter": "KhudaDadNomani",
-        "linkedin": "khudadadnomani",
-        "availableForHire": false,
-        "repos": [
-            "optimizer"
-        ]
-    },
-    {
-        "name": "Lukasz Gornicki",
-        "github": "derberg",
-        "linkedin": "lukasz-gornicki-a621914",
-        "twitter": "derberq",
-        "availableForHire": false,
-        "company": "Postman",
-        "repos": [
-            "avro-schema-parser",
-            "openapi-schema-parser",
-            "chatbot",
-            "diff",
-            "cli",
-            "generator-filters",
-            "generator-hooks",
-            "github-action-for-generator",
-            "generator",
-            "nodejs-template",
-            "nodejs-ws-template",
-            "parser-js",
-            "playground",
-            "spec",
-            "spec-json-schemas",
-            "template-for-generator-templates",
-            "website"
-        ]
-    },
-    {
-        "name": "Maciej Urbańczyk",
-        "github": "magicmatatjahu",
-        "availableForHire": false,
-        "linkedin": "maciej-urbańczyk-909547164",
-        "company": "Postman",
-        "repos": [
-            "asyncapi-react",
-            "chatbot",
-            "cli",
-            "generator-react-sdk",
-            "generator",
-            "html-template",
-            "markdown-template",
-            "parser-js",
-            "playground",
-            "website"
-        ]
-    },
-    {
-        "github": "AceTheCreator",
-        "twitter": "_acebuild",
-        "availableForHire": false,
-        "repos": [
-            "chatbot"
-        ]
-    },
-    {
-        "name": "Souvik De",
-        "github": "Souvikns",
-        "twitter": "souvik_ns",
-        "linkedin": "souvik-de-a2b941169",
-        "availableForHire": false,
-        "repos": [
-            "cli"
-        ]
-    },
-    {
-        "github": "Pakisan",
-        "availableForHire": false,
-        "repos": [
-            "jasyncapi"
-        ]
-    },
-    {
-        "name": "Michael Davis",
-        "github": "damaru-inc",
-        "availableForHire": false,
-        "company": "Solace",
-        "repos": [
-            "java-spring-cloud-stream-template",
-            "python-paho-template"
-        ]
-    },
-    {
-        "github": "NektariosFifes",
-        "availableForHire": false,
-        "repos": [
-            "simulator"
-        ]
-    }
+    [
+        {
+            "name": "Aayush Sahu",
+            "github": "aayushmau5",
+            "linkedin": "aayushmau5",
+            "twitter": "aayushmau5",
+            "availableForHire": false,
+            "repos": [
+                "diff"
+            ]
+        },
+        {
+            "name": "Arjun Garg",
+            "github": "arjungarg07",
+            "linkedin": "arjungarg17",
+            "twitter": "ArjunGarg07",
+            "availableForHire": false,
+            "repos": [
+                "cupid"
+            ]
+        },
+        {
+            "name": "Emiliano Zublena",
+            "github": "emilianozublena",
+            "availableForHire": false,
+            "repos": [
+                "asyncapi-php-template"
+            ]
+        },
+        {
+            "name": "Fran Méndez",
+            "github": "fmvilas",
+            "availableForHire": false,
+            "company": "Postman",
+            "linkedin": "fmvilas",
+            "repos": [
+                "raml-dt-schema-parser",
+                "avro-schema-parser",
+                "openapi-schema-parser",
+                "asyncapi-react",
+                "glee",
+                "generator",
+                "nodejs-template",
+                "nodejs-ws-template",
+                "parser-js",
+                "playground",
+                "spec",
+                "spec-json-schemas",
+                "website",
+                "bindings"
+            ]
+        },
+        {
+            "name": "Jonas Lagoni",
+            "github": "jonaslagoni",
+            "linkedin": "jonaslagoni",
+            "availableForHire": false,
+            "company": "Postman",
+            "repos": [
+                "dotnet-nats-template",
+                "ts-nats-template",
+                "generator-react-sdk",
+                "generator",
+                "modelina",
+                "parser-js",
+                "simulator"
+            ]
+        },
+        {
+            "name": "Jorge Aguiar Martín",
+            "github": "jotamusik",
+            "linkedin": "jorge-aguiar-martin",
+            "twitter": "jotamusik",
+            "availableForHire": false,
+            "company": "LeanMind",
+            "repos": [
+                "cli"
+            ]
+        },
+        {
+            "name": "Khuda Dad Nomani",
+            "github": "KhudaDad414",
+            "twitter": "KhudaDadNomani",
+            "linkedin": "khudadadnomani",
+            "availableForHire": false,
+            "repos": [
+                "optimizer"
+            ]
+        },
+        {
+            "name": "Lukasz Gornicki",
+            "github": "derberg",
+            "linkedin": "lukasz-gornicki-a621914",
+            "twitter": "derberq",
+            "availableForHire": false,
+            "company": "Postman",
+            "repos": [
+                "avro-schema-parser",
+                "openapi-schema-parser",
+                "chatbot",
+                "diff",
+                "cli",
+                "generator-filters",
+                "generator-hooks",
+                "github-action-for-generator",
+                "generator",
+                "nodejs-template",
+                "nodejs-ws-template",
+                "parser-js",
+                "playground",
+                "spec",
+                "spec-json-schemas",
+                "template-for-generator-templates",
+                "website"
+            ]
+        },
+        {
+            "name": "Maciej Urbańczyk",
+            "github": "magicmatatjahu",
+            "availableForHire": false,
+            "linkedin": "maciej-urbańczyk-909547164",
+            "company": "Postman",
+            "repos": [
+                "asyncapi-react",
+                "chatbot",
+                "cli",
+                "generator-react-sdk",
+                "generator",
+                "html-template",
+                "markdown-template",
+                "parser-js",
+                "playground",
+                "website"
+            ]
+        },
+        {
+            "github": "AceTheCreator",
+            "twitter": "_acebuild",
+            "availableForHire": false,
+            "repos": [
+                "chatbot"
+            ]
+        },
+        {
+            "name": "Souvik De",
+            "github": "Souvikns",
+            "twitter": "souvik_ns",
+            "linkedin": "souvik-de-a2b941169",
+            "availableForHire": false,
+            "repos": [
+                "cli"
+            ]
+        },
+        {
+            "github": "Pakisan",
+            "availableForHire": false,
+            "repos": [
+                "jasyncapi"
+            ]
+        },
+        {
+            "name": "Michael Davis",
+            "github": "damaru-inc",
+            "availableForHire": false,
+            "company": "Solace",
+            "repos": [
+                "java-spring-cloud-stream-template",
+                "python-paho-template"
+            ]
+        },
+        {
+            "github": "NektariosFifes",
+            "availableForHire": false,
+            "repos": [
+                "simulator"
+            ]
+        }
+    ]
 ]

--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -1,0 +1,178 @@
+[
+  {
+    "name": "Lukasz Gornicki",
+    "github": "derberg",
+    "linkedin": "lukasz-gornicki-a621914",
+    "twitter": "derberq",
+    "availableForHire": false,
+    "company": "Postman",
+    "repos": [
+      "avro-schema-parser",
+      "openapi-schema-parser",
+      "chatbot",
+      "diff",
+      "cli",
+      "generator-filters",
+      "generator-hooks",
+      "github-action-for-generator",
+      "generator",
+      "nodejs-template",
+      "nodejs-ws-template",
+      "parser-js",
+      "playground",
+      "spec",
+      "spec-json-schemas",
+      "template-for-generator-templates",
+      "website"
+    ]
+  },
+  {
+    "name": "Aayush Sahu",
+    "github": "aayushmau5",
+    "linkedin": "aayushmau5",
+    "twitter": "aayushmau5",
+    "availableForHire": false,
+    "repos": [
+      "diff"
+    ]
+  },
+  {
+    "name": "Emiliano Zublena",
+    "github": "emilianozublena",
+    "availableForHire": false,
+    "repos": [
+      "asyncapi-php-template"
+    ]
+  },
+  {
+    "name": "Maciej Urbańczyk",
+    "github": "magicmatatjahu",
+    "availableForHire": false,
+    "linkedin": "maciej-urbańczyk-909547164",
+    "company": "Postman",
+    "repos": [
+      "asyncapi-react",
+      "chatbot",
+      "cli",
+      "generator-react-sdk",
+      "generator",
+      "html-template",
+      "markdown-template",
+      "parser-js",
+      "playground",
+      "website"
+    ]
+  },
+  {
+    "name": "Fran Méndez",
+    "github": "fmvilas",
+    "availableForHire": false,
+    "company": "Postman",
+    "linkedin": "fmvilas",
+    "repos": [
+      "raml-dt-schema-parser",
+      "avro-schema-parser",
+      "openapi-schema-parser",
+      "asyncapi-react",
+      "glee",
+      "generator",
+      "nodejs-template",
+      "nodejs-ws-template",
+      "parser-js",
+      "playground",
+      "spec",
+      "spec-json-schemas",
+      "website",
+      "bindings"
+    ]
+  },
+  {
+    "github": "AceTheCreator",
+    "twitter": "_acebuild",
+    "availableForHire": false,
+    "repos": [
+      "chatbot"
+    ]
+  },
+  {
+    "name": "Souvik De",
+    "github": "Souvikns",
+    "twitter": "souvik_ns",
+    "linkedin": "souvik-de-a2b941169",
+    "availableForHire": false,
+    "repos": [
+      "cli"
+    ]
+  },
+  {
+    "name": "Jorge Aguiar Martín",
+    "github": "jotamusik",
+    "linkedin": "jorge-aguiar-martin",
+    "twitter": "jotamusik",
+    "availableForHire": false,
+    "company": "LeanMind",
+    "repos": [
+      "cli"
+    ]
+  },
+  {
+    "name": "Arjun Garg",
+    "github": "arjungarg07",
+    "linkedin": "arjungarg17",
+    "twitter": "ArjunGarg07",
+    "availableForHire": false,
+    "repos": [
+      "cupid"
+    ]
+  },
+  {
+    "name": "Jonas Lagoni",
+    "github": "jonaslagoni",
+    "linkedin": "jonaslagoni",
+    "availableForHire": false,
+    "company": "Postman",
+    "repos": [
+      "dotnet-nats-template",
+      "ts-nats-template",
+      "generator-react-sdk",
+      "generator",
+      "modelina",
+      "parser-js",
+      "simulator"
+    ]
+  },
+  {
+    "github": "Pakisan",
+    "availableForHire": false,
+    "repos": [
+      "jasyncapi"
+    ]
+  },
+  {
+    "name": "Michael Davis",
+    "github": "damaru-inc",
+    "availableForHire": false,
+    "company": "Solace",
+    "repos": [
+      "java-spring-cloud-stream-template",
+      "python-paho-template"
+    ]
+  },
+  {
+    "name": "Khuda Dad Nomani",
+    "github": "KhudaDad414",
+    "twitter": "KhudaDadNomani",
+    "linkedin": "khudadadnomani",
+    "availableForHire": false,
+    "repos": [
+      "optimizer"
+    ]
+  },
+  {
+    "github": "NektariosFifes",
+    "availableForHire": false,
+    "repos": [
+      "simulator"
+    ]
+  }
+]

--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -23,6 +23,7 @@
         {
             "name": "Emiliano Zublena",
             "github": "emilianozublena",
+            "linkedin": "emilianozublena",
             "availableForHire": false,
             "repos": [
                 "asyncapi-php-template"

--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -1,178 +1,178 @@
 [
-  {
-    "name": "Lukasz Gornicki",
-    "github": "derberg",
-    "linkedin": "lukasz-gornicki-a621914",
-    "twitter": "derberq",
-    "availableForHire": false,
-    "company": "Postman",
-    "repos": [
-      "avro-schema-parser",
-      "openapi-schema-parser",
-      "chatbot",
-      "diff",
-      "cli",
-      "generator-filters",
-      "generator-hooks",
-      "github-action-for-generator",
-      "generator",
-      "nodejs-template",
-      "nodejs-ws-template",
-      "parser-js",
-      "playground",
-      "spec",
-      "spec-json-schemas",
-      "template-for-generator-templates",
-      "website"
-    ]
-  },
-  {
-    "name": "Aayush Sahu",
-    "github": "aayushmau5",
-    "linkedin": "aayushmau5",
-    "twitter": "aayushmau5",
-    "availableForHire": false,
-    "repos": [
-      "diff"
-    ]
-  },
-  {
-    "name": "Emiliano Zublena",
-    "github": "emilianozublena",
-    "availableForHire": false,
-    "repos": [
-      "asyncapi-php-template"
-    ]
-  },
-  {
-    "name": "Maciej Urbańczyk",
-    "github": "magicmatatjahu",
-    "availableForHire": false,
-    "linkedin": "maciej-urbańczyk-909547164",
-    "company": "Postman",
-    "repos": [
-      "asyncapi-react",
-      "chatbot",
-      "cli",
-      "generator-react-sdk",
-      "generator",
-      "html-template",
-      "markdown-template",
-      "parser-js",
-      "playground",
-      "website"
-    ]
-  },
-  {
-    "name": "Fran Méndez",
-    "github": "fmvilas",
-    "availableForHire": false,
-    "company": "Postman",
-    "linkedin": "fmvilas",
-    "repos": [
-      "raml-dt-schema-parser",
-      "avro-schema-parser",
-      "openapi-schema-parser",
-      "asyncapi-react",
-      "glee",
-      "generator",
-      "nodejs-template",
-      "nodejs-ws-template",
-      "parser-js",
-      "playground",
-      "spec",
-      "spec-json-schemas",
-      "website",
-      "bindings"
-    ]
-  },
-  {
-    "github": "AceTheCreator",
-    "twitter": "_acebuild",
-    "availableForHire": false,
-    "repos": [
-      "chatbot"
-    ]
-  },
-  {
-    "name": "Souvik De",
-    "github": "Souvikns",
-    "twitter": "souvik_ns",
-    "linkedin": "souvik-de-a2b941169",
-    "availableForHire": false,
-    "repos": [
-      "cli"
-    ]
-  },
-  {
-    "name": "Jorge Aguiar Martín",
-    "github": "jotamusik",
-    "linkedin": "jorge-aguiar-martin",
-    "twitter": "jotamusik",
-    "availableForHire": false,
-    "company": "LeanMind",
-    "repos": [
-      "cli"
-    ]
-  },
-  {
-    "name": "Arjun Garg",
-    "github": "arjungarg07",
-    "linkedin": "arjungarg17",
-    "twitter": "ArjunGarg07",
-    "availableForHire": false,
-    "repos": [
-      "cupid"
-    ]
-  },
-  {
-    "name": "Jonas Lagoni",
-    "github": "jonaslagoni",
-    "linkedin": "jonaslagoni",
-    "availableForHire": false,
-    "company": "Postman",
-    "repos": [
-      "dotnet-nats-template",
-      "ts-nats-template",
-      "generator-react-sdk",
-      "generator",
-      "modelina",
-      "parser-js",
-      "simulator"
-    ]
-  },
-  {
-    "github": "Pakisan",
-    "availableForHire": false,
-    "repos": [
-      "jasyncapi"
-    ]
-  },
-  {
-    "name": "Michael Davis",
-    "github": "damaru-inc",
-    "availableForHire": false,
-    "company": "Solace",
-    "repos": [
-      "java-spring-cloud-stream-template",
-      "python-paho-template"
-    ]
-  },
-  {
-    "name": "Khuda Dad Nomani",
-    "github": "KhudaDad414",
-    "twitter": "KhudaDadNomani",
-    "linkedin": "khudadadnomani",
-    "availableForHire": false,
-    "repos": [
-      "optimizer"
-    ]
-  },
-  {
-    "github": "NektariosFifes",
-    "availableForHire": false,
-    "repos": [
-      "simulator"
-    ]
-  }
+    {
+        "name": "Aayush Sahu",
+        "github": "aayushmau5",
+        "linkedin": "aayushmau5",
+        "twitter": "aayushmau5",
+        "availableForHire": false,
+        "repos": [
+            "diff"
+        ]
+    },
+    {
+        "name": "Arjun Garg",
+        "github": "arjungarg07",
+        "linkedin": "arjungarg17",
+        "twitter": "ArjunGarg07",
+        "availableForHire": false,
+        "repos": [
+            "cupid"
+        ]
+    },
+    {
+        "name": "Emiliano Zublena",
+        "github": "emilianozublena",
+        "availableForHire": false,
+        "repos": [
+            "asyncapi-php-template"
+        ]
+    },
+    {
+        "name": "Fran Méndez",
+        "github": "fmvilas",
+        "availableForHire": false,
+        "company": "Postman",
+        "linkedin": "fmvilas",
+        "repos": [
+            "raml-dt-schema-parser",
+            "avro-schema-parser",
+            "openapi-schema-parser",
+            "asyncapi-react",
+            "glee",
+            "generator",
+            "nodejs-template",
+            "nodejs-ws-template",
+            "parser-js",
+            "playground",
+            "spec",
+            "spec-json-schemas",
+            "website",
+            "bindings"
+        ]
+    },
+    {
+        "name": "Jonas Lagoni",
+        "github": "jonaslagoni",
+        "linkedin": "jonaslagoni",
+        "availableForHire": false,
+        "company": "Postman",
+        "repos": [
+            "dotnet-nats-template",
+            "ts-nats-template",
+            "generator-react-sdk",
+            "generator",
+            "modelina",
+            "parser-js",
+            "simulator"
+        ]
+    },
+    {
+        "name": "Jorge Aguiar Martín",
+        "github": "jotamusik",
+        "linkedin": "jorge-aguiar-martin",
+        "twitter": "jotamusik",
+        "availableForHire": false,
+        "company": "LeanMind",
+        "repos": [
+            "cli"
+        ]
+    },
+    {
+        "name": "Khuda Dad Nomani",
+        "github": "KhudaDad414",
+        "twitter": "KhudaDadNomani",
+        "linkedin": "khudadadnomani",
+        "availableForHire": false,
+        "repos": [
+            "optimizer"
+        ]
+    },
+    {
+        "name": "Lukasz Gornicki",
+        "github": "derberg",
+        "linkedin": "lukasz-gornicki-a621914",
+        "twitter": "derberq",
+        "availableForHire": false,
+        "company": "Postman",
+        "repos": [
+            "avro-schema-parser",
+            "openapi-schema-parser",
+            "chatbot",
+            "diff",
+            "cli",
+            "generator-filters",
+            "generator-hooks",
+            "github-action-for-generator",
+            "generator",
+            "nodejs-template",
+            "nodejs-ws-template",
+            "parser-js",
+            "playground",
+            "spec",
+            "spec-json-schemas",
+            "template-for-generator-templates",
+            "website"
+        ]
+    },
+    {
+        "name": "Maciej Urbańczyk",
+        "github": "magicmatatjahu",
+        "availableForHire": false,
+        "linkedin": "maciej-urbańczyk-909547164",
+        "company": "Postman",
+        "repos": [
+            "asyncapi-react",
+            "chatbot",
+            "cli",
+            "generator-react-sdk",
+            "generator",
+            "html-template",
+            "markdown-template",
+            "parser-js",
+            "playground",
+            "website"
+        ]
+    },
+    {
+        "github": "AceTheCreator",
+        "twitter": "_acebuild",
+        "availableForHire": false,
+        "repos": [
+            "chatbot"
+        ]
+    },
+    {
+        "name": "Souvik De",
+        "github": "Souvikns",
+        "twitter": "souvik_ns",
+        "linkedin": "souvik-de-a2b941169",
+        "availableForHire": false,
+        "repos": [
+            "cli"
+        ]
+    },
+    {
+        "github": "Pakisan",
+        "availableForHire": false,
+        "repos": [
+            "jasyncapi"
+        ]
+    },
+    {
+        "name": "Michael Davis",
+        "github": "damaru-inc",
+        "availableForHire": false,
+        "company": "Solace",
+        "repos": [
+            "java-spring-cloud-stream-template",
+            "python-paho-template"
+        ]
+    },
+    {
+        "github": "NektariosFifes",
+        "availableForHire": false,
+        "repos": [
+            "simulator"
+        ]
+    }
 ]


### PR DESCRIPTION
**Description**

I finally realized that I will never have time to finalize entire TSC members list automation in one run, especially that ya got no skills to do website UI without initial design from someone who has a better sense of esthetics 😄 

- TSC_MEMBERS.json file with the list of all TSC members. Not YAML as it doesn't have to be super human-readable as long term the file is supposed to be updated by the bot + nicely rendered in the AsyncAPI website 
- 2 GH actions workflows 
  - one to validate if JSON file has proper structure and if all members added to the file can actually be there according to the open governance model
  - another to push new file version to website repo
- this is how we calculate that at the moment there can be only 4 representatives from the same company: 
  ```js
  const members = require('./TSC_MEMBERS.json');
  const allMembers = members.length; //14
  const allowedMemberPerCompany = (allMembers/4).toFixed(0); //4

  //next time when we can have 5 people from the same company is when the total number of members reaches 18
  ```

All TSC members added to the list should review it, suggest changes to provided information (especially hire availability) + approve the PR:
- @fmvilas 
- @jonaslagoni 
- @magicmatatjahu 
- @KhudaDad414
- @NektariosFifes
- @damaru-inc
- @Pakisan
- @arjungarg07
- @jotamusik
- @Souvikns
- @AceTheCreator
- @emilianozublena
- @aayushmau5
- @derberg 

Once you change `"availableForHire": false` to `true`, long term in the UI it will be visible for all, like a label around the profile photo

**Related issue(s)**
See also https://github.com/asyncapi/.github/issues/47