### PR TITLE
docs: improving community meetings README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <a href="https://opencollective.com/asyncapi">Donate :raised_hands:</a>
 </p>
 
-## Platinum Sponsors
+## Platinum sponsors
 <p align="center">
   <a href="https://iqvia.com">
     <img src="./assets/iqvia.png" alt="IQVIA logo" height="40">
@@ -54,32 +54,29 @@
   :raised_hands: <a href="https://opencollective.com/asyncapi">Become a sponsor</a> :raised_hands:
 </p>
 
-## Meetings
+## AsyncAPI community meetings
+AsyncAPI hosts and records community interest meetings bi-weekly on Tuesdays. We rotate the time at which we host these meetings; 4:00pm UTC one Tuesday and 8:00am UTC the next Tuesday. Rotating the time of our community meetings allows us to meet with community members from APAC, Europe, and Americas. 🌎 🌍 🌎
 
-We host and record community interest meetings bi-weekly on Tuesdays. Meetings rotate from 4:00pm UTC one Tuesday and then 8:00am UTC the next Tuesday. Rotating the time of our bi-community meetings allows us to meet with community members from APAC, Europe and Americas. 
+## Add AsyncAPI meetings to calendar
+There are two simple ways to join _any_ and _all_ AsyncAPI community meetings:
+- **Add our [calendar](https://calendar.google.com/calendar?cid=dGJyYmZxNGRlNWJjbmd0OG9rdmV2NGxzdGtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ):** check out when we meet next! 🗓️ 
+- **Join our [mailing list](https://groups.google.com/forum/#!forum/asyncapi-users):** receive an invite to our next meeting. 📨  
 
-Check out our [calendar](https://calendar.google.com/calendar?cid=dGJyYmZxNGRlNWJjbmd0OG9rdmV2NGxzdGtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) to see when we're meeting next or join [this](https://groups.google.com/forum/#!forum/asyncapi-users) mailing list go get an invite to the next meeting. 
+## Join AsyncAPI meetings
+Great news! You can join our community meetings with Zoom or from your phone. Follow the agenda for both past and future meetings [here](https://github.com/asyncapi/community/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Ameeting+sort%3Acreated-desc+), in our GitHub pinned issue 🐙.
 
-Join from your favorite device: https://zoom.us/j/165106914
+- Join our [Zoom call](https://zoom.us/j/165106914) from your favorite device. 
+- Dial in.
 
-Or dialing:
+| **Meeting ID: 165 106 914**   |                                         |
+|-------------------------------|-----------------------------------------|
+| :us: United States of America | +1 720 707 2699 </br>+1 646 558 8656    |
+| :es: Spain                    | +34 91 198 0188 </br> +34 84 368 5025   |
+| :gb: United Kingdom           | +44 203 695 0088 </br> +44 203 051 2874 |
 
-Meeting ID: 165 106 914
+## Community meeting recordings
 
-:us: United States of America
-* [+1 720 707 2699](tel:+17207072699)
-* [+1 646 558 8656](tel:+16465588656)
+Head over to our [AsyncAPI Youtube playlist of SIG meetings](https://www.youtube.com/watch?v=S8gvf0XjO10&list=PLbi1gRlP7pijUwZJErzyYf_Rc-PWu4lXS) to watch them. 🎥 
 
-:es: Spain
-* [+34 91 198 0188](tel:+34911980188)
-* [+34 84 368 5025](tel:+34843685025)
+[![AsyncAPI Youtube playlist of SIG meetings](https://i.ytimg.com/vi/8ddwX0CyUeE/hqdefault.jpg)](https://www.youtube.com/watch?v=S8gvf0XjO10&list=PLbi1gRlP7pijUwZJErzyYf_Rc-PWu4lXS)
 
-:gb: United Kingdom
-* [+44 203 695 0088](tel:+442036950088)
-* [+44 203 051 2874](tel:+442030512874)
-
-Find the agenda for our past and future meetings [here](https://github.com/asyncapi/community/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Ameeting+sort%3Acreated-desc+) in the pinned issue.
-
-## Meeting recordings
-
-Head over to the [Youtube playlist for SIG meetings](https://www.youtube.com/watch?v=S8gvf0XjO10&list=PLbi1gRlP7pijUwZJErzyYf_Rc-PWu4lXS) to watch them.


### PR DESCRIPTION
We've received feedback from CCOSS attendees and our SIG calls that our AsyncAPI Community Meeting README file isn't as clear or informative as it could be for new folks joining this community. 

This PR includes the following:
- Clarifying and bringing better visibility to how community members can be aware of and follow all AsyncAPI community meetings.
- Improved intro explanation of how Tuesday meeting times swap works, to accommodate diff timezones. 
- Added sections to clarify action items and prompt action from reader:
   -  **Add** AsyncAPI meetings to calendar
   - **Join** AsyncAPI meetings
   - **Watch** meeting recordings
- Added YT video tile to encourage people to click and start watching the playlist 
- Added table to help reduce scrolling for the long content of international phone numbers
- Added emojis to add happiness 🤩