### PR TITLE
chore: add workflow to semi automate creation of issues related to events

### DIFF
--- a/.github/workflows/EVENTS_ORGANIZATION.md
+++ b/.github/workflows/EVENTS_ORGANIZATION.md
@@ -1,0 +1,31 @@
+This document covers the technical aspect of events organization. It describes the basic steps required for every official AsyncAPI event.
+
+## AsyncAPI Calendar
+
+Every event must be created in [AsyncAPI Google Calendar](https://calendar.google.com/calendar/u/0/embed?src=tbrbfq4de5bcngt8okvev4lstk@group.calendar.google.com) and an invitation sent to asyncapi-users@googlegroups.com.
+
+You need to be a member of [this](https://groups.google.com/u/1/g/asyncapi-users) user group to get an invitation.
+
+<iframe src="https://calendar.google.com/calendar/embed?src=tbrbfq4de5bcngt8okvev4lstk%40group.calendar.google.com&ctz=Europe%2FWarsaw" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+
+## Event-related GitHub issue
+
+Every event instance must have a corresponding GitHub issue with details on schedule and how to participate. Such an issue must be created in [the community repository](https://github.com/asyncapi/community/issues).
+
+The next meeting should be pinned to the list of all issues using `Pin issue` feature.
+
+The issue creation process for official AsyncAPI events is semi-automated. You do not have to create an issue on your own, but you can trigger a dedicated GitHub Action workflow to do it for you.
+
+1. Go to [**Actions** tab](https://github.com/asyncapi/community/actions)
+2. Select **Create community event issue** workflow
+3. Click **Run workflow** button
+4. Provide data required by the form and click another **Run workflow** button visible in the form
+
+As a result, a new GitHub issue is created in the repository.
+
+> You need to manually close issues for old meetings and manage pinned issues.
+
+## New events registration
+
+* To get new issue registered in AsyncAPI Calendar, contact with the community in `#events` channel in [Slack](https://www.asyncapi.com/slack-invite),
+* To modify an issue creation workflow to support a new event, modify [this workflow](.github/workflows/create-event-issue.yml) and add a new script like [this one](.github/workflows/event_issue_templates/sig.js).

--- a/.github/workflows/EVENTS_ORGANIZATION.md
+++ b/.github/workflows/EVENTS_ORGANIZATION.md
@@ -25,5 +25,5 @@ As a result, a new GitHub issue is created in the repository.
 
 ## New events registration
 
-* To get new issue registered in AsyncAPI Calendar, contact with the community in `#events` channel in [Slack](https://www.asyncapi.com/slack-invite),
+* To get a new issue registered in AsyncAPI Calendar, contact the community in the `#events` channel in [Slack](https://www.asyncapi.com/slack-invite),
 * To modify an issue creation workflow to support a new event, modify [this workflow](.github/workflows/create-event-issue.yml) and add a new script like [this one](.github/workflows/event_issue_templates/sig.js).

--- a/.github/workflows/EVENTS_ORGANIZATION.md
+++ b/.github/workflows/EVENTS_ORGANIZATION.md
@@ -6,8 +6,6 @@ Every event must be created in [AsyncAPI Google Calendar](https://calendar.googl
 
 You need to be a member of [this](https://groups.google.com/u/1/g/asyncapi-users) user group to get an invitation.
 
-<iframe src="https://calendar.google.com/calendar/embed?src=tbrbfq4de5bcngt8okvev4lstk%40group.calendar.google.com&ctz=Europe%2FWarsaw" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-
 ## Event-related GitHub issue
 
 Every event instance must have a corresponding GitHub issue with details on schedule and how to participate. Such an issue must be created in [the community repository](https://github.com/asyncapi/community/issues).

--- a/.github/workflows/create-event-issue.yml
+++ b/.github/workflows/create-event-issue.yml
@@ -1,0 +1,63 @@
+name: Create community event issue
+
+on:
+  workflow_dispatch:
+    inputs:
+      time:
+        description: 'Info about meeting hour in UTC time zone, like: 8AM'
+        required: true
+      everytimezone:
+        description: 'Link that points to specific time when meeting happens so others can translate it to their time zones, like: https://everytimezone.com/s/182f3172'
+        required: true
+      date:
+        description: 'Date in a form like: Tuesday October 26 2021'
+        required: true
+      type:
+        description: 'Is it "sig" or "contributor_first" meeting'
+        required: true
+
+jobs:
+
+  setup-sig-meeting:
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    name: Setup SIG meeting
+    runs-on: ubuntu-latest
+    if: github.event.inputs.type == 'sig'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Create issue content
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const { writeFileSync } = require('fs');
+            const { getMeetingIssueContent } = require('./.github/workflows/event_issue_templates/sig.js');
+
+            const issueContent =  getMeetingIssueContent('${{ github.event.inputs.time }}', '${{ github.event.inputs.everytimezone }}');
+
+            writeFileSync('content.md', issueContent, { encoding: 'utf8'});
+      - name: Create issue with meeting details
+        run: gh issue create -l meeting -t "AsyncAPI Contributor-first meeting, ${{ github.event.inputs.date }} ${{ github.event.inputs.time }} UTC" -F content.md
+
+  setup-contributor-first-meeting:
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    name: Setup Community-first meeting
+    runs-on: ubuntu-latest
+    if: github.event.inputs.type == 'contributor_first'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Create issue content
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const { writeFileSync } = require('fs');
+            const { getMeetingIssueContent } = require('./.github/workflows/event_issue_templates/contributor-first.js');
+
+            const issueContent =  getMeetingIssueContent('${{ github.event.inputs.time }}', '${{ github.event.inputs.everytimezone }}');
+
+            writeFileSync('content.md', issueContent, { encoding: 'utf8'});
+      - name: Create issue with meeting details
+        run: gh issue create -l meeting -t "AsyncAPI Contributor-first meeting, ${{ github.event.inputs.date }} ${{ github.event.inputs.time }} UTC" -F content.md

--- a/.github/workflows/event_issue_templates/contributor-first.js
+++ b/.github/workflows/event_issue_templates/contributor-first.js
@@ -1,0 +1,18 @@
+module.exports.getMeetingIssueContent = (time, everytimezone) => {
+
+    return `The purpose of this meeting is to focus on contributors, focus on people that want to contribute to AsyncAPI Initiative but do not know how to do it. AsyncAPI Initiative is a large project, with lots of code, lots of docs, and many many other areas that need help, but it is not easy to start.
+
+Recordings from the previous meetings are available in [this](https://www.youtube.com/playlist?list=PLbi1gRlP7pigPBrBMaNQhUeniR1pdDMiY) playlist on YouTube.
+
+**This time we meet at [${time} UTC](${everytimezone})**
+
+Join [this](https://groups.google.com/forum/#!forum/asyncapi-users) mailing list to get an always-up-to-date invite to the meeting in your calendar. You can also check [AsyncAPI Calendar](https://calendar.google.com/calendar/u/0/embed?src=tbrbfq4de5bcngt8okvev4lstk@group.calendar.google.com).
+
+This meatin is a live-stream that goes to the following social media:
+- [YouTube](https://www.youtube.com/asyncapi)
+- [Twitch](https://www.twitch.tv/asyncapi)
+- [Twitter](https://twitter.com/AsyncAPISpec)
+- [LinkedIn](https://www.linkedin.com/company/asyncapi)
+
+To broadcast the live-stream, we are using [Restream](https://restream.io/). You are invited to join us live on the call and not only interact through chats on YouTube and Twitch.`
+}

--- a/.github/workflows/event_issue_templates/sig.js
+++ b/.github/workflows/event_issue_templates/sig.js
@@ -1,0 +1,28 @@
+module.exports.getMeetingIssueContent = (time, everytimezone) => {
+
+    return `This is the meeting for the AsyncAPI Special Interest Group (SIG). You're invited to [join us](https://zoom.us/j/165106914) and ask questions. **The meeting takes place on alternate Tuesdays**. Recordings from the previous meetings are available in [this](https://www.youtube.com/playlist?list=PLbi1gRlP7pijUwZJErzyYf_Rc-PWu4lXS) playlist on YouTube.
+
+**This time we meet at [${time} UTC](${everytimezone})**
+
+Join [this](https://groups.google.com/forum/#!forum/asyncapi-users) mailing list to get an always-up-to-date invite to the meeting in your calendar. You can also check [AsyncAPI Calendar](https://calendar.google.com/calendar/u/0/embed?src=tbrbfq4de5bcngt8okvev4lstk@group.calendar.google.com).
+
+## Agenda
+
+> Don't wait for the meeting to discuss topics that already have issues. Feel free to comment on them earlier.
+
+1. Q&A
+1. _Place for your topic_
+1. Q&A
+
+## Notes
+
+tbd
+
+## Chat
+
+tbd
+
+## Recording
+
+tbd`
+}


### PR DESCRIPTION
In recent days we discuss how to make sure our community meetings are visible, and what is the source of truth.

I do not think anyone objects to the current idea of having GitHub Issue per event.

But this is so boring to create these, like seriously, fully manual job and this is why I did not create them for contributor-first meetings.

We need a bit of automation here, especially that more and more meetings will come, @fmvilas will from time to time run Thinking Out Loud, @boyney123 has an idea for another series, and tbh looking at the trend we will grow here even more in the coming months.

> this semi-automation was inspired by a great idea from @MikeRalphson for OAI ([this](https://github.com/OAI/OpenAPI-Specification/blob/main/.github/workflows/agenda.yaml) and [this](https://github.com/OAI/OpenAPI-Specification/blob/main/.github/templates/agenda.md). I just added some customizations

What this PR introduces:
- GH Actions workflow that can be manually triggered
- This workflow can create SIG meeting issue and Contributor-first meeting issue
- This is how triggering looks like
    <img width="2202" alt="Screenshot 2021-10-15 at 11 42 04" src="https://user-images.githubusercontent.com/6995927/137468847-f3580db5-704e-48de-b3f9-667bb0606e01.png">
- This is example output -> https://github.com/derberg/test-experiment/issues/83