### PR TITLE
ci: add workflows to automate merging of human-actor created PRs

### DIFF
--- a/.github/workflows/add-ready-to-merge-label.yml
+++ b/.github/workflows/add-ready-to-merge-label.yml
@@ -1,0 +1,26 @@
+#This workflow is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+
+#Purpose of this workflow is to enable anyone to label PR with `ready-to-merge` label to get it merged
+name: Add ready-to-merge label # if proper comment added
+
+on: issue_comment
+
+jobs:
+
+  parse-comment-and-add-label:
+    if: github.event.issue.pull_request && github.event.issue.state != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label
+        if: contains(github.event.comment.body, '/ready-to-merge') || contains(github.event.comment.body, '/rtm' )
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['ready-to-merge']
+            })

--- a/.github/workflows/automerge-for-humans.yml
+++ b/.github/workflows/automerge-for-humans.yml
@@ -1,0 +1,34 @@
+#This workflow is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+
+#Purpose of this workflow is to allow people to merge PR without a need of maintainer doing it. If all checks are in place (including maintainers approval) - JUST MERGE IT!
+name: Automerge For Humans
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  
+jobs:
+
+  automerge-for-humans:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automerge PR
+        uses: pascalgn/automerge-action@v0.14.3
+        if: github.actor != 'asyncapi-bot' || github.actor != 'dependabot[bot]' || github.actor != 'dependabot-preview[bot]' #it runs only if PR actor is not a bot, at least not a bot that we know
+        env:
+          GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
+          MERGE_LABELS: "ready-to-merge"
+          MERGE_METHOD: "squash"
+          MERGE_COMMIT_MESSAGE: "pull-request-title"
+          MERGE_RETRIES: "20"
+          MERGE_RETRY_SLEEP: "30000"


### PR DESCRIPTION
Fixes https://github.com/asyncapi/.github/issues/31

## Why we need it

- AsyncAPI GitHub organization members have **write** access:
  - security problem when we get at scale (we actually already are)
  -  CODEOWNERS restrictions do not work and people that are not in this file but have Wrote on org can approve PRs and merge even though they are not official maintainers
- We have more and more maintainers, there are from time to time mistakes made when PR is merged, that conventional commits spec is wrong, even PR title is correct. Humans make mistakes, bots don't

## AsyncAPI GH org changes

Once we are happy with the proposed workflows, this is what will change in the GH org settings:
- Organization members will have only **read** access
- We invite all TSC members to be organization members and they can also transparently show it on their GH profiles if they want
- We can finally create a TSC GitHub team in organization so we can ping team for important PRs
- All maintainers are no longer `outside collaborators` but will have `write` access on "their" repos individually 

## Change in how maintainers work

**You can still work as before** 
**BUT IT DOESN'T MAKE SENSE 😆 **

- repo maintainers still need `write` level access to the given repo otherwise CODEOWNERS do not work 😞 
- this means you as a maintainer can still manually merge a PR
- you still need to be able to write as there are some edge cases that I can elaborate more on, if this is important for you

Still, I recommend below!

### Lukasz's recommended way of working

You are happy with PR, all checks passed? you already approved? DON'T merge manually:
- sometimes we humans forget to make sure the commit message follows semantic versioning as expected. 
- sometimes we even forget that we should merge

**Just add `/ready-to-merge` or `/rtm` comment** (can be multiline as in example below)

1. if PR is not draft and not closed, `ready-to-merge`label will be added
2. `automerge for humans` workflow will trigger (it triggers also because of other events)
3.  if all required checks are green, required approvals in place then the PR will be squash-merged  using the PR title (so you do not have to worry about it when merging)

## What is missing here

Docs and education. No workflow that would put info on PR about the special comment that people can use. Simple because let us first use it for a couple of weeks to make sure all works well.

## Proof workflows work

Test PR that proves that PR is labeled only when a proper comment is done. You can also see there merging was done, it looks like it is me but only because auto-merge bot in my tests use my token:

<img width="1882" alt="Screenshot 2021-10-21 at 12 58 55" src="https://user-images.githubusercontent.com/6995927/138269028-3bf7f3e6-991d-4ccd-9ed2-8f15ed1f72dd.png">

