### PR TITLE
chore: better naming meetings for event issues

### DIFF
--- a/.github/workflows/create-event-issue.yml
+++ b/.github/workflows/create-event-issue.yml
@@ -38,7 +38,7 @@ jobs:
 
             writeFileSync('content.md', issueContent, { encoding: 'utf8'});
       - name: Create issue with meeting details
-        run: gh issue create -l meeting -t "AsyncAPI Contributor-first meeting, ${{ github.event.inputs.date }} ${{ github.event.inputs.time }} UTC" -F content.md
+        run: gh issue create -l meeting -t "Contributor-first Meeting, ${{ github.event.inputs.time }} UTC ${{ github.event.inputs.date }}" -F content.md
 
   setup-contributor-first-meeting:
     env:
@@ -60,4 +60,4 @@ jobs:
 
             writeFileSync('content.md', issueContent, { encoding: 'utf8'});
       - name: Create issue with meeting details
-        run: gh issue create -l meeting -t "AsyncAPI Contributor-first meeting, ${{ github.event.inputs.date }} ${{ github.event.inputs.time }} UTC" -F content.md
+        run: gh issue create -l meeting -t "Community SIG Meeting, ${{ github.event.inputs.time }} UTC ${{ github.event.inputs.date }}" -F content.md


### PR DESCRIPTION
After this change, the meeting will be created with a focus on hour first, it looks better on the list, especially for pinned issues. With the previous approach, you actually had to hover over the pinned issue or click it to see the hour


New approach 👇🏼 

<img width="1861" alt="Screenshot 2021-10-26 at 15 23 00" src="https://user-images.githubusercontent.com/6995927/138887736-88e8e7c1-c44f-48d2-b920-686f21fd1810.png">
