### PR TITLE
chore: add java-template maintainers to TSC

### DIFF
--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -301,5 +301,44 @@
 		"repos": [
 			"server-api"
 		]
+	},
+	{
+		"name": "Daniel Raper",
+		"github": "dan-r",
+		"linkedin": "danielr",
+		"availableForHire": false,
+		"company": "IBM",
+		"repos": [
+			"java-template"
+		]
+	},
+	{
+		"name": "Kieran Murphy",
+		"github": "KieranM1999",
+		"linkedin": "kieran-murphy-175b0412b",
+		"availableForHire": false,
+		"company": "IBM",
+		"repos": [
+			"java-template"
+		]
+	},
+	{
+		"name": "Tom Jefferson",
+		"github": "JEFFLUFC",
+		"linkedin": "t-jefferson",
+		"availableForHire": false,
+		"company": "IBM",
+		"repos": [
+			"java-template"
+		]
+	},
+	{
+		"name": "Lewis Relph",
+		"github": "lewis-relph",
+		"availableForHire": false,
+		"company": "IBM",
+		"repos": [
+			"java-template"
+		]
 	}
 ]

--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -48,7 +48,8 @@
 		"company": "IBM",
 		"repos": [
 			"avro-schema-parser",
-			"bindings"
+			"bindings",
+			"java-template"
 		]
 	},
 	{


### PR DESCRIPTION
Hi all 👋 

As maintainers of [asyncapi/java-template](https://github.com/asyncapi/java-template), we'd like to join the TSC and be more involved with the AsyncAPI community. We are all currently at IBM, and with the 2 current members this keeps us under the per-organisation limit.

Thank you for your consideration and we look forward to hearing from the existing TSC members!

-Dan, Kieran, Tom and Lewis

