### PR TITLE
chore: add automation for new 3.0 release related meeting

### DIFF
--- a/.github/workflows/create-event-issue.yml
+++ b/.github/workflows/create-event-issue.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       time:
-        description: 'Info about meeting hour in UTC time zone, like: 8AM'
+        description: 'Info about meeting hour in UTC time zone, like: 8 or 16'
         required: true
       everytimezone:
         description: 'Link that points to specific time when meeting happens so others can translate it to their time zones, like: https://everytimezone.com/s/182f3172'
@@ -13,8 +13,12 @@ on:
         description: 'Date in a form like: Tuesday October 26 2021'
         required: true
       type:
-        description: 'Is it "sig" or "contributor_first" meeting'
+        description: 'Is it "sig" or "lets_talk_contrib" meeting'
         required: true
+      descSuffix:
+        description: 'You can specify additional text that appears at the end of generated event title, like: - Product Design'
+        required: false
+        default: ''
 
 jobs:
 
@@ -38,14 +42,14 @@ jobs:
 
             writeFileSync('content.md', issueContent, { encoding: 'utf8'});
       - name: Create issue with meeting details
-        run: gh issue create -l meeting -t "Community SIG Meeting, ${{ github.event.inputs.time }} UTC ${{ github.event.inputs.date }}" -F content.md
+        run: gh issue create -l meeting -t "Community SIG Meeting, ${{ github.event.inputs.time }} UTC ${{ github.event.inputs.date }} ${{ github.event.inputs.descSuffix }}" -F content.md
 
-  setup-contributor-first-meeting:
+  setup-lets-talk-about-contrib-stream:
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-    name: Setup Community-first meeting
+    name: Setup Lets talk about contributing live stream
     runs-on: ubuntu-latest
-    if: github.event.inputs.type == 'contributor_first'
+    if: github.event.inputs.type == 'lets_talk_contrib'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -60,4 +64,26 @@ jobs:
 
             writeFileSync('content.md', issueContent, { encoding: 'utf8'});
       - name: Create issue with meeting details
-        run: gh issue create -l meeting -t "Contributor-first Meeting, ${{ github.event.inputs.time }} UTC ${{ github.event.inputs.date }}" -F content.md
+        run: gh issue create -l meeting -t "Let's talk about contributing, ${{ github.event.inputs.time }} UTC ${{ github.event.inputs.date }} ${{ github.event.inputs.descSuffix }}" -F content.md
+
+  setup-spec-3-0-meeting:
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    name: Setup meeting about 3.0 spec work
+    runs-on: ubuntu-latest
+    if: github.event.inputs.type == 'sig'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Create issue content
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const { writeFileSync } = require('fs');
+            const { getMeetingIssueContent } = require('./.github/workflows/event_issue_templates/sig.js');
+
+            const issueContent =  getMeetingIssueContent('${{ github.event.inputs.time }}', '${{ github.event.inputs.everytimezone }}');
+
+            writeFileSync('content.md', issueContent, { encoding: 'utf8'});
+      - name: Create issue with meeting details
+        run: gh issue create -l meeting -t "Spec 3.0 Meeting, ${{ github.event.inputs.time }} UTC ${{ github.event.inputs.date }} ${{ github.event.inputs.descSuffix }}" -F content.md

--- a/.github/workflows/create-event-issue.yml
+++ b/.github/workflows/create-event-issue.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           script: |
             const { writeFileSync } = require('fs');
-            const { getMeetingIssueContent } = require('./.github/workflows/event_issue_templates/sig.js');
+            const { getMeetingIssueContent } = require('./.github/workflows/event_issue_templates/spec-3-0.js');
 
             const issueContent =  getMeetingIssueContent('${{ github.event.inputs.time }}', '${{ github.event.inputs.everytimezone }}');
 

--- a/.github/workflows/event_issue_templates/spec-3-0.js
+++ b/.github/workflows/event_issue_templates/spec-3-0.js
@@ -1,0 +1,30 @@
+module.exports.getMeetingIssueContent = (time, everytimezone) => {
+
+    return `This is the meeting for community member involved in works related to 3.0 release of AsyncAPI Specification. 
+    
+**The meeting takes place bi-weekly on Wednesdays**. First and third week every month until release. Recordings from the previous meetings are available in [this](https://www.youtube.com/playlist?list=PLbi1gRlP7pihClJY-kXuTRRJ8n1awb0VV) playlist on YouTube.
+
+**This time we meet at [${time} UTC](${everytimezone})**
+
+Join [this](https://groups.google.com/forum/#!forum/asyncapi-users) mailing list to get an always-up-to-date invite to the meeting in your calendar. You can also check [AsyncAPI Calendar](https://calendar.google.com/calendar/u/0/embed?src=tbrbfq4de5bcngt8okvev4lstk@group.calendar.google.com).
+
+## Agenda
+
+> Don't wait for the meeting to discuss topics that already have issues. Feel free to comment on them earlier.
+
+1. Q&A
+1. _Place for your topic_
+1. Q&A
+
+## Notes
+
+tbd
+
+## Chat
+
+tbd
+
+## Recording
+
+tbd`
+}

--- a/.github/workflows/event_issue_templates/spec-3-0.js
+++ b/.github/workflows/event_issue_templates/spec-3-0.js
@@ -6,7 +6,7 @@ module.exports.getMeetingIssueContent = (time, everytimezone) => {
 
 **This time we meet at [${time} UTC](${everytimezone})**
 
-Join [this](https://groups.google.com/forum/#!forum/asyncapi-users) mailing list to get an always-up-to-date invite to the meeting in your calendar. You can also check [AsyncAPI Calendar](https://calendar.google.com/calendar/u/0/embed?src=tbrbfq4de5bcngt8okvev4lstk@group.calendar.google.com).
+Join [this mailing list](https://groups.google.com/forum/#!forum/asyncapi-users) to get an always-up-to-date invite to the meeting in your calendar. You can also check [AsyncAPI Calendar](https://calendar.google.com/calendar/u/0/embed?src=tbrbfq4de5bcngt8okvev4lstk@group.calendar.google.com).
 
 ## Agenda
 

--- a/EVENTS_ORGANIZATION.md
+++ b/EVENTS_ORGANIZATION.md
@@ -10,8 +10,6 @@ You need to be a member of [this](https://groups.google.com/u/1/g/asyncapi-users
 
 Every event instance must have a corresponding GitHub issue with details on schedule and how to participate. Such an issue must be created in [the community repository](https://github.com/asyncapi/community/issues).
 
-The next meeting should be pinned to the list of all issues using `Pin issue` feature.
-
 The issue creation process for official AsyncAPI events is semi-automated. You do not have to create an issue on your own, but you can trigger a dedicated GitHub Action workflow to do it for you.
 
 1. Go to [**Actions** tab](https://github.com/asyncapi/community/actions)


### PR DESCRIPTION
Missing: info about where meeting is hosted. Related https://github.com/asyncapi/community/discussions/157#discussioncomment-1963382

This PR added new job that creates issue for new meeting related to AsyncAPI spec 3.0 release