### PR TITLE
ci: fix mailchimp campaign schedule with meetings list

### DIFF
--- a/.github/workflows/create-event-helpers/calendar/index.js
+++ b/.github/workflows/create-event-helpers/calendar/index.js
@@ -124,17 +124,15 @@ async function listEvents() {
     let eventsItems;
 
     try {
-        //this runs always on friday midnight
+        //this runs always on sunday midnight
         const currentTime = new Date(Date.now()).toISOString();
-        //we check moday
-        const timeIn2Days = new Date(Date.parse(currentTime) + 2 * 24 * 60 * 60 * 1000).toISOString();
         //till friday
-        const timeIn8Days = new Date(Date.parse(currentTime) + 8 * 24 * 60 * 60 * 1000).toISOString();
+        const endTime = new Date(Date.parse(currentTime) + 6 * 24 * 60 * 60 * 1000).toISOString();
 
         const eventsList = await calendar.events.list({
             calendarId: process.env.CALENDAR_ID,
-            timeMax: timeIn8Days,
-            timeMin: timeIn2Days
+            timeMax: endTime,
+            timeMin: currentTime
         })
 
         eventsItems = eventsList.data.items.map((e) => {

--- a/.github/workflows/create-event-helpers/mailchimp/index.js
+++ b/.github/workflows/create-event-helpers/mailchimp/index.js
@@ -54,7 +54,8 @@ module.exports = async () => {
     * We schedule an email, we do not send it at midnight immediately but use schedule with `timewarp` to basically send email at the same time for anyone no matter what time zone they live in
     */
     try {
-        const scheduleDate = new Date(Date.now());
+        //next day 11:00
+        const scheduleDate = new Date(Date.parse(new Date(Date.now()).toISOString()) + 1 * 24 * 60 * 60 * 1000);
         scheduleDate.setUTCHours(11);
         scheduleDate.setUTCMinutes(00);
 

--- a/.github/workflows/send-events-newsletter.yml
+++ b/.github/workflows/send-events-newsletter.yml
@@ -2,8 +2,8 @@ name: Send email to newsletter subscribers about upcomming meetings
 
 on:
   schedule:
-    # Runs "At 00:00 on Friday." (see https://crontab.guru)
-    - cron: '00 00 * * 5'
+    # Runs "At 00:00 on Sunday." (see https://crontab.guru)
+    - cron: '00 00 * * 7'
 
 jobs:
 


### PR DESCRIPTION
Unfortunately, the first attempt to send a newsletter with a meetings list failed. Reason is that when you schedule campaign, it must be at least 24h in the future 🤦🏼 -> https://github.com/asyncapi/community/runs/6121221255?check_suite_focus=true

At the moment this PR introduces simple fix, but it means that because we run cron job midnight Thu/Fri then email with meetings list is sent out not 11:00AM Friday but 11:00AM Saturday.

I'm not 100% sure it is good. 
Other options:
- run the cron job just a day before, Wed/Thu and still send newsletter on Friday. Disadvantage is that meetings hosts need to remember to always schedule meetings latest on Wednesday. Not very bad but still some kind of limitation
- switch from campaign schedule to "immediate" sent, so we run Cron job on Friday 11AM and send the newsletter. Disadvantage is that we do not use MailChimp smart schedule, so that it is sent 11AM for anyone, no matter what time zone are they in, but 11AM Google Action time, so for some people it can be actually 6PM and for some 2AM 🤷🏼 

I think the best would be to modify this PR and do "until Wednesday schedule approach"

Thoughts?

@fmvilas @jonaslagoni asking you directly as you are hosts that will have to follow the changes
