### PR TITLE
ci: fix sending newsletter sunday cron schedule

### DIFF
--- a/.github/workflows/send-events-newsletter.yml
+++ b/.github/workflows/send-events-newsletter.yml
@@ -3,7 +3,7 @@ name: Send email to newsletter subscribers about upcomming meetings
 on:
   schedule:
     # Runs "At 00:00 on Sunday." (see https://crontab.guru)
-    - cron: '00 00 * * 7'
+    - cron: '00 00 * * 0'
 
 jobs:
 


### PR DESCRIPTION
newsletter with meetings list was not sent again :(

I changed it to Sunday which according to https://crontab.guru/#00_00_*_*_7 is 7
but unfortunately, it returns:

![Screenshot 2022-05-10 at 17 20 39](https://user-images.githubusercontent.com/6995927/167664043-eb94bed2-27a5-4e5a-b1d6-cf886ae77ae6.png)

apparently, for them Sunday is worth `0`

![Screenshot 2022-05-10 at 17 21 14](https://user-images.githubusercontent.com/6995927/167664159-77c7170c-9c3f-4051-90cf-3e61ff93c582.png)

