### PR TITLE
ci: add missing zoom link for 3.0 meeting 

### DIFF
--- a/.github/workflows/create-event-helpers/issues_templates/spec-3-0.md
+++ b/.github/workflows/create-event-helpers/issues_templates/spec-3-0.md
@@ -22,7 +22,7 @@ labels: meeting
 </tr>
 <tr>
 <td>Zoom</td>
-<td>Zoom link is not available. This is a live stream event. Watch and interact through one of below mentioned platforms.</td>
+<td><a href="{{ env.ZOOM_LINK }}">Join live</a>.</td>
 </tr>
 <tr>
 <td>YouTube</td>


### PR DESCRIPTION
**Description**
Zoom link is not being generated for the issue.