### PR TITLE
feat: add Ace as an alternative host for create event ad hoc

### DIFF
--- a/.github/workflows/create-event-ad-hoc.yml
+++ b/.github/workflows/create-event-ad-hoc.yml
@@ -26,7 +26,7 @@ jobs:
       meeting_name: ${{ github.event.inputs.name }}
       meeting_desc: ${{ github.event.inputs.desc }}
       host: lpgornicki@gmail.com
-      alternative_host: "fmvilas@gmail.com,jonas-lt@live.dk"
+      alternative_host: "fmvilas@gmail.com,jonas-lt@live.dk,devlopergene@gmail.com"
       issue_template_path: .github/workflows/create-event-helpers/issues_templates/ad-hoc.md
       create_zoom: true
     secrets:


### PR DESCRIPTION
Ace would love to be added as an alternative host for create event ad hoc
