### PR TITLE
chore(tsc): add @whitlockjc to TSC_MEMBERS.json

### DIFF
--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -411,5 +411,16 @@
 		"repos": [
 			"vs-asyncapi-preview"
 		]
+	},
+	{
+		"name": "Jeremy Whitlock",
+		"github": "whitlockjc",
+		"linkedin": "whitlockjc",
+		"twitter": "whitlockjc",
+		"availableForHire": false,
+		"company": "Google",
+		"repos": [
+			"bindings"
+		]
 	}
 ]


### PR DESCRIPTION
**Description**

Add @whitlockjc to `TSC_MEMBERS.json` for [bindings](https://github.com/asyncapi/bindings).

**Related issue(s)**

* https://github.com/asyncapi/bindings/pull/141
