### PR TITLE
chore(tsc): add Vladimír Gorej + add repos to Sergio Moya

### DIFF
--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -278,6 +278,7 @@
 		"availableForHire": false,
 		"company": "Postman",
 		"repos": [
+			"bindings",
 			"converter-go",
 			"event-gateway",
 			"go-watermill-template",
@@ -285,6 +286,8 @@
 			"parser-api",
 			"parser-go",
 			"server-api",
+			"spec",
+			"spec-json-schemas",
 			"template-for-go-projects"
 		]
 	},
@@ -421,6 +424,19 @@
 		"company": "Google",
 		"repos": [
 			"bindings"
+		]
+	},
+	{
+		"name": "Vladimír Gorej",
+		"github": "char0n",
+		"linkedin": "vladimirgorej",
+		"twitter": "vladimirgorej",
+		"availableForHire": false,
+		"company": "SmartBear",
+		"repos": [
+			"bindings",
+			"spec",
+			"spec-json-schemas"
 		]
 	}
 ]


### PR DESCRIPTION
**Description**

According to https://github.com/asyncapi/spec/pull/846#issuecomment-1274886976, @char0n wants to become member of the TSC, as it is now Code Owner of 3 repositories.

This PR adds @char0n to the list of TSC members + updates the recent repositories @smoya became Code Owner of.

**Related issue(s)**
https://github.com/asyncapi/spec/pull/846