### PR TITLE
docs: correct filenames for manual and automated tools

### DIFF
--- a/new-tool-documentation.md
+++ b/new-tool-documentation.md
@@ -88,13 +88,13 @@ filters:
 
 ## Manual addition of tools
 
-If you don't want to create the `.asyncapi-tool` file in your repository or your tool's codebase doesn't exist in Github, the [AsyncAPI website repository](https://github.com/asyncapi/website) contains a [`manual-tools.json`](https://github.com/asyncapi/website/blob/master/config/tools-manual.json) file that adds your tool to our website's [Tools Dashboard](/tools).
+If you don't want to create the `.asyncapi-tool` file in your repository or your tool's codebase doesn't exist in Github, the [AsyncAPI website repository](https://github.com/asyncapi/website) contains a [`tools-manual.json`](https://github.com/asyncapi/website/blob/master/config/tools-manual.json) file that adds your tool to our website's [Tools Dashboard](/tools).
 
-Inside this [`manual-tools.json`](https://github.com/asyncapi/website/blob/master/config/tools-manual.json) file, you must choose the desired category for your tool and add your tool as an **element** inside that particular category **object**.
+Inside this [`tools-manual.json`](https://github.com/asyncapi/website/blob/master/config/tools-manual.json) file, you must choose the desired category for your tool and add your tool as an **element** inside that particular category **object**.
 
 ## JSON tool structure
 
-Once you've created your `.asyncapi-tool` file, check your tool configuration inside our database on the [automated-tools.json](https://github.com/asyncapi/website/blob/master/config/tools-automated.json) file.
+Once you've created your `.asyncapi-tool` file, check your tool configuration inside our database on the [tools-automated.json](https://github.com/asyncapi/website/blob/master/config/tools-automated.json) file.
 
 Here's what a sample JSON object for an AsyncAPI tool should look like after it is added to the final [tools.json](https://github.com/asyncapi/website/blob/master/config/tools.json) that keeps the information about all tools added manually and through `.asyncapi-tool` file:
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Correct filenames in documentation:
  - `manual-tools.json` -> `tools-manual.json`
  - `automated-tools.json` -> `tools-automated.json`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

None