### PR TITLE
fix: added missing meeting banner env

### DIFF
--- a/.github/workflows/create-event-workflow-reusable.yml
+++ b/.github/workflows/create-event-workflow-reusable.yml
@@ -127,6 +127,7 @@ jobs:
           MEETING_NAME: ${{ inputs.meeting_name }}
           MEETING_NAME_SUFFIX: ${{ inputs.meeting_name_suffix }}
           MEETING_DESC: ${{ inputs.meeting_desc }}
+          MEETING_BANNER: ${{ inputs.meeting_banner }}
           GUEST: ${{ inputs.guest }}
         with:
           script: |

--- a/.github/workflows/create-event-workflow-reusable.yml
+++ b/.github/workflows/create-event-workflow-reusable.yml
@@ -121,7 +121,7 @@ jobs:
           GUEST: ${{ inputs.guest }}
         with:
           filename: ${{ inputs.issue_template_path }}
-      - name: Create Google Calendar entry with zoom
+      - name: Create Google Calendar entry
         uses: actions/github-script@v4
         env:
           MEETING_NAME: ${{ inputs.meeting_name }}


### PR DESCRIPTION
When creating meetings, I noticed the meeting banner URL isn't included when adding an event to the calendar :( 

cc @derberg 