### PR TITLE
chore: add GreenRover to TSC_MEMBERS

### DIFF
--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -555,7 +555,7 @@
 			 "community"
 		]
 	},
-		{
+	{
 		"name": "Kenneth Aasan",
 		"github": "kennethaasan",
 		"slack": "U037S2HK4TS",
@@ -565,5 +565,16 @@
 		"repos": [
 			"modelina"
 		]
+	},
+	{
+		"name": "Heiko Henning",
+		"github": "GreenRover",
+		"slack": "U03AC4G51H8",
+		"availableForHire": false,
+		"company": "mtrail GmbH",
+		"repos": [
+			"protobuf-schema-parser"
+		]
 	}
+	
 ]


### PR DESCRIPTION
**Description**

- Recently I hand over protobuff schema parser to community
- Modified TSC_MEMBERS.json to add myself as a member

**Related issue(s)**
