### PR TITLE
ci: fix meeting scheduling bug when time is 9

### DIFF
--- a/.github/workflows/create-event-helpers/calendar/index.js
+++ b/.github/workflows/create-event-helpers/calendar/index.js
@@ -33,7 +33,7 @@ async function addEvent(zoomUrl, startDate, startTime, issueNumber) {
         //helper to create end time which is always 1h later
         const getEndTime = (startTime) => {
             const time = Number(startTime);
-            if (time < 10) return '0' + (time + 1)
+            if (time < 9) return '0' + (time + 1)
 
             return (time + 1) + ''
         }


### PR DESCRIPTION
calendar entry creation fails when hour is 9 because then the end time is `2023-04-26T010:00:00Z` which is bad as it should be `T10` not `T010`.
