### PR TITLE
docs: new automation for spec 3 docs meetings

### DIFF
--- a/.github/workflows/create-event-helpers/issues_templates/spec-3-docs.md
+++ b/.github/workflows/create-event-helpers/issues_templates/spec-3-docs.md
@@ -1,0 +1,77 @@
+---
+title: "{{ env.MEETING_NAME }}, {{ env.FULL_DATE | date('H:mm [UTC] dddd MMMM Do YYYY') }}"
+labels: meeting
+---
+
+<img src="{{ env.MEETING_BANNER }}" alt="" />
+
+<table>
+<tr>
+<th>Meeting Info</th>
+<th>Details</th>
+</tr>
+<tr>
+<td>Purpose</td>
+<td>{{ env.MEETING_DESC }}</td>
+</tr>
+<tr>
+<td>Time</td>
+<td><strong>{{ env.FULL_DATE | date('H') }}:00 UTC</strong> | Translate to your time zone with the <a href="https://dateful.com/convert/coordinated-universal-time-utc?t={{ env.FULL_DATE | date('kk') }}&d={{ env.DATE_ONLY }}">time zone converter</a>.</td>
+</tr>
+<tr>
+<th>Meeting Place</th>
+<th>Link</th>
+</tr>
+<tr>
+<td>Zoom</td>
+<td><a href="{{ env.ZOOM_LINK }}">Join live</a>.</td>
+</tr>
+<tr>
+<td>YouTube</td>
+<td><a href="https://www.youtube.com/asyncapi">Watch live and interact through live chat</a>.</td>
+</tr>
+<tr>
+<td>Twitch</td>
+<td><a href="https://www.twitch.tv/asyncapi">Watch live</a>.</td>
+</tr>
+<tr>
+<td>Twitter</td>
+<td><a href="https://twitter.com/AsyncAPISpec">Watch live</a>.</td>
+</tr>
+<tr>
+<td>LinkedIn</td>
+<td><a href="https://www.linkedin.com/company/asyncapi">Watch live</a>.</td>
+</tr>
+<tr>
+<th>More Info</th>
+<th>Details</th>
+</tr>
+<tr>
+<td>Meeting Recordings</td>
+<td><a href="https://www.youtube.com/playlist?list=PLbi1gRlP7pihClJY-kXuTRRJ8n1awb0VV">YouTube Playlist</a>.</td>
+</tr>
+<tr>
+<td>AsyncAPI Initiative Calendar</td>
+<td><a href="https://calendar.google.com/calendar/embed?src=c_q9tseiglomdsj6njuhvbpts11c%40group.calendar.google.com&ctz=UTC">Public URL</a>.</td>
+</tr>
+<tr>
+<td>iCal File</td>
+<td><a href="https://calendar.google.com/calendar/ical/c_q9tseiglomdsj6njuhvbpts11c%40group.calendar.google.com/public/basic.ics">Add to your calendar</a>.</td>
+</tr>
+<tr>
+<td>Newsletter</td>
+<td><a href="https://www.asyncapi.com/community/meetings">Subscribe to get weekly updates on upcoming meetings</a>.</td>
+</tr>
+</table>
+
+## Agenda
+
+> Don't wait for the meeting to discuss topics that already have issues. Feel free to comment on them earlier.
+
+1. Q&A
+1. _Place for your topic_
+1. Q&A
+
+## Notes
+
+_Add notes here after the meeting._

--- a/.github/workflows/create-event-spec-3-docs.yml
+++ b/.github/workflows/create-event-spec-3-docs.yml
@@ -1,0 +1,41 @@
+name: Schedule Spec 3.0 Docs Meeting
+
+on:
+  workflow_dispatch:
+    inputs:
+      time:
+        description: 'Info about meeting hour in UTC time zone, like: 08 or 16. No PM or AM versions.'
+        required: true
+      date:
+        description: 'Date in a form like: 2022-04-05 where 04 is a month and 05 is a day number.'
+        required: true
+      meeting_banner: 
+        description: 'Meeting banner(image) URL'
+        required: false
+
+jobs:
+
+  setup-spec-3-docs-meeting:
+    uses: ./.github/workflows/create-event-workflow-reusable.yml
+    with:
+      time: ${{ github.event.inputs.time }}
+      date: ${{ github.event.inputs.date }}
+      meeting_banner: ${{ github.event.inputs.meeting_banner }}
+      meeting_name: Spec 3.0 Docs Meeting
+      meeting_desc: This is a open meeting to plan and write Spec 3.0 Docs.
+      host: alejandra.olvera.novack@gmail.com
+      alternative_host: "fmvilas@gmail.com,devlopergene@gmail.com,sibanda.thulie@gmail.com,jonas-lt@live.dk,lpgornicki@gmail.com"
+      issue_template_path: .github/workflows/create-event-helpers/issues_templates/spec-3-docs.md
+      create_zoom: true
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      ZOOM_API_KEY: ${{ secrets.ZOOM_API_KEY }}
+      ZOOM_API_SECRET: ${{ secrets.ZOOM_API_SECRET }}
+      STREAM_URL: ${{ secrets.STREAM_URL }}
+      STREAM_KEY: ${{ secrets.STREAM_KEY }}
+      CALENDAR_ID: ${{ secrets.CALENDAR_ID }}
+      CALENDAR_SERVICE_ACCOUNT: ${{ secrets.CALENDAR_SERVICE_ACCOUNT }}
+      TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }} 
+      TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }} 
+      TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }} 
+      TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}


### PR DESCRIPTION
Adding new OPEN meeting to plan and write Spec 3.0 Docs.

cc @jonaslagoni 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->