### PR TITLE
docs: add README.md and update status of 2023 Async API Mentorship cycle 

### DIFF
--- a/mentorship/asyncapi-mentorship/2023/README.md
+++ b/mentorship/asyncapi-mentorship/2023/README.md
@@ -1,0 +1,26 @@
+# Status: In progress
+
+## Timeline
+
+- Project proposals applications open: April 1st - June 6th
+- Mentees applications open: June 6th - June 23rd
+- Application review by the mentors/admission decisions: June 23rd - June 28th
+
+Mentorship duration - seven months \(full-time schedule\)
+
+
+## Accepted projects
+ 
+Number | Project Idea | Category | Mentor(s) | Mentee(s)
+---|---|---|---|---
+1 | [Add help/{command} endpoint](https://github.com/asyncapi/server-api/issues/144) | Engineering | [BOLT04](https://github.com/BOLT04) | [@princerajpoot20](https://github.com/princerajpoot20)
+2 | [Website UI Kit design/dev project](https://github.com/asyncapi/design-system/issues/4) | Design | [AceTheCreator](https://github.com/AceTheCreator) | [@Mayaleeeee](https://github.com/Mayaleeeee)
+3 | [MVP integration of extensions catalog with AsyncAPI tools](https://github.com/asyncapi/extensions-catalog/issues/78) | Enginerring | [Lukasz Gornicki](https://github.com/derberg) | [@sambhavgupta0705](https://github.com/sambhavgupta0705) |
+4 | [Documenting how different protocols work with AsyncAPI](https://github.com/orgs/asyncapi/discussions/533) | Documentation | [Alejandra Quetzalli](https://github.com/alequetzalli) | [@alequetzalli](https://github.com/alequetzalli)  
+5 | [Rewrite this template and NodeJS WS template](https://github.com/asyncapi/nodejs-template/issues/133) | Engineering | [Lukasz Gornicki](https://github.com/derberg) | |
+6 |	[Simulator Desktop Application](https://github.com/asyncapi/community/issues/691) | Engineering | [Nektarios Fifes](https://github.com/NektariosFifes) | |	
+7 |	[Tutorial document or separate guides for glee](https://github.com/asyncapi/glee/issues/431) | Documentation | [Souvik](https://github.com/Souvikns) & [Khuda Dad Nomani](https://github.com/KhudaDad414) |  |
+8 |	[Add support for translations](https://github.com/asyncapi/website/issues/267) | Engineering | [Maciej Urbańczyk](https://github.com/magicmatatjahu) | |
+9 |	[Prepare CLI for v1.0.0 release](https://github.com/asyncapi/cli/issues/599) | Engineering | [Souvik](https://github.com/Souvikns) | |	
+10 | [DocsUI: Messages Object output](https://github.com/asyncapi/asyncapi-react/issues/618) | Design | [Missy Turco ](https://github.com/mcturco) & [Fran Méndez](https://github.com/fmvilas) | |
+11 | [DocsUI: UX/UI updates](https://github.com/asyncapi/asyncapi-react/issues/617) | Design | [Missy Turco ](https://github.com/mcturco) & [Fran Méndez](https://github.com/fmvilas) | |

--- a/mentorship/asyncapi-mentorship/README.md
+++ b/mentorship/asyncapi-mentorship/README.md
@@ -5,7 +5,7 @@ The AsyncAPI Mentorship makes it easy to sponsor and help train the next generat
 ## Program Cycles and Archive data
 | Year | Term   | Status    | Announcement                                                                                                                                                         | Details                                 |
 | ---- | ------ | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| 2023 | Apr-Dec | In progress   |       | [Apr-Dec](2023/README.md) |
+| 2023 | Jan-Nov | In progress   |       | [Jan-Nov](2023/README.md) |
 | 2022 | Jan-Nov | Completed   |       | [Jan-Nov](2022/README.md) |
 
 ## Current cycle

--- a/mentorship/asyncapi-mentorship/README.md
+++ b/mentorship/asyncapi-mentorship/README.md
@@ -5,11 +5,11 @@ The AsyncAPI Mentorship makes it easy to sponsor and help train the next generat
 ## Program Cycles and Archive data
 | Year | Term   | Status    | Announcement                                                                                                                                                         | Details                                 |
 | ---- | ------ | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| 2023 | Jan-Nov | Planning   |       | [Jan-Nov](2023/README.md) |
-| 2022 | Jan-Nov | In progress   |       | [Jan-Nov](2022/README.md) |
+| 2023 | Apr-Dec | In progress   |       | [Apr-Dec](2023/README.md) |
+| 2022 | Jan-Nov | Completed   |       | [Jan-Nov](2022/README.md) |
 
 ## Current cycle
-The AsyncAPI Mentorship program current cycle is 2022 and more details are coming in Q1 of 2023. The next cycle will kick off Q1 of 2023
+The AsyncAPI Mentorship program current cycle is 2023 and will run till Dec 2023.
 
 ## Program Maintainers
 


### PR DESCRIPTION
**Description**
Adds README.md with accepted projects.

Updates status of current cycle of Async API Mentorship to 2023 and marks 2022 as completed. 



**Related issue(s)**
Resolves #757 