### PR TITLE
ci: update MAINTAINERS.yaml based on CODEOWNERS changes

### DIFF
--- a/.github/workflows/update-maintainers.yml
+++ b/.github/workflows/update-maintainers.yml
@@ -27,12 +27,31 @@ jobs:
 
       - run: cd community && git checkout HEAD^
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install js-yaml
+        run: npm install js-yaml@3.14.1
+
+      - name: Get repository name
+        run: |
+          REPO_NAME=$(basename ${{ github.repository }})
+          echo "REPO_NAME=$REPO_NAME" >> $GITHUB_ENV
+          echo "Repository Name: $REPO_NAME"
+
       - name: Compare CODEOWNERS
         id: compare-codeowners
         uses: actions/github-script@v6
         with:
           script: |
-            const fs = require('fs');      
+            const fs = require('fs');
+            const yaml = require('js-yaml');
+
+            // Get repository name
+            const repoName = process.env.REPO_NAME;
+
             function extractGitHubUsernames(content) {
               const regex = /@([a-zA-Z0-9_-]+)/g;
               const matches = content.match(regex);
@@ -42,18 +61,50 @@ jobs:
               return matches.map(match => match.substr(1));
             }
       
-            const oldCodeowners = fs.readFileSync('./community-main/CODEOWNERS', 'utf8');
+            const mainCodeowners = fs.readFileSync('./community-main/CODEOWNERS', 'utf8');
             const prCodeowners = fs.readFileSync('./community/CODEOWNERS', 'utf8');
       
-            const oldUsernames = extractGitHubUsernames(oldCodeowners);
+            const mainUsernames = extractGitHubUsernames(mainCodeowners);
             const prUsernames = extractGitHubUsernames(prCodeowners);
-      
-            const addedUsernames = oldUsernames.filter(username => !prUsernames.includes(username));
-            const removedUsernames = prUsernames.filter(username => !oldUsernames.includes(username));
 
-      
+            const addedUsernames = mainUsernames.filter(username => !prUsernames.includes(username));
+            const removedUsernames = prUsernames.filter(username => !mainUsernames.includes(username));
             console.log('Added Usernames:', addedUsernames);
             console.log('Removed Usernames:', removedUsernames);
-      
             console.log(`ADDED_USERNAMES=${addedUsernames.join(', ')}`);
             console.log(`REMOVED_USERNAMES=${removedUsernames.join(', ')}`);
+
+            // Update MAINTAINERS.yaml
+            const maintainersFile = './community-main/MAINTAINERS.yaml';
+            const maintainers = yaml.safeLoad(fs.readFileSync(maintainersFile, 'utf8'));
+
+            // Update for added usernames
+            addedUsernames.forEach(username => {
+              const existingMaintainer = maintainers.find(maintainer => maintainer.github === username);
+              if (!existingMaintainer) {
+                maintainers.push({
+                  github: username,
+                  isTscMember: false,
+                  repos: [repoName]
+                });
+                console.log('Added maintainer:', username);
+              } else {
+                console.log('Maintainer', username, 'already exists. Skipping addition.');
+              }
+            });
+
+            // Update for removed usernames
+            removedUsernames.forEach(username => {
+              const index = maintainers.findIndex(maintainer => maintainer.github === username);
+              if (index !== -1) {
+                maintainers.splice(index, 1);
+                console.log('Removed maintainer:', username);
+              } else {
+                console.log('Maintainer', username, 'does not exist. Skipping removal.');
+              }
+            });
+
+            // Write updated MAINTAINERS.yaml file
+            const updatedMaintainers = yaml.safeDump(maintainers);
+            fs.writeFileSync(maintainersFile, updatedMaintainers);
+            console.log('Updated MAINTAINERS.yaml:', updatedMaintainers);

--- a/.github/workflows/update-maintainers.yml
+++ b/.github/workflows/update-maintainers.yml
@@ -125,3 +125,9 @@ jobs:
             const updatedMaintainers = yaml.safeDump(maintainers);
             fs.writeFileSync(maintainersFile, updatedMaintainers);
             console.log('Updated MAINTAINERS.yaml:', updatedMaintainers);
+      - name: Commit and push
+        working-directory: ./community-main
+        run: |
+          git add .
+          git commit -m "Update MAINTAINERS.yaml"
+          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} master

--- a/.github/workflows/update-maintainers.yml
+++ b/.github/workflows/update-maintainers.yml
@@ -1,0 +1,59 @@
+name: Update MAINTAINERS.yaml
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'CODEOWNERS'
+
+jobs:
+  compare-codeowners:
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          path: community-main
+
+      - name: Checkout one commit before last one
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+          ref: master
+          path: community
+
+      - run: cd community && git checkout HEAD^
+
+      - name: Compare CODEOWNERS
+        id: compare-codeowners
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');      
+            function extractGitHubUsernames(content) {
+              const regex = /@([a-zA-Z0-9_-]+)/g;
+              const matches = content.match(regex);
+              if (!matches) {
+                return [];
+              }
+              return matches.map(match => match.substr(1));
+            }
+      
+            const oldCodeowners = fs.readFileSync('./community-main/CODEOWNERS', 'utf8');
+            const prCodeowners = fs.readFileSync('./community/CODEOWNERS', 'utf8');
+      
+            const oldUsernames = extractGitHubUsernames(oldCodeowners);
+            const prUsernames = extractGitHubUsernames(prCodeowners);
+      
+            const addedUsernames = oldUsernames.filter(username => !prUsernames.includes(username));
+            const removedUsernames = prUsernames.filter(username => !oldUsernames.includes(username));
+
+      
+            console.log('Added Usernames:', addedUsernames);
+            console.log('Removed Usernames:', removedUsernames);
+      
+            console.log(`ADDED_USERNAMES=${addedUsernames.join(', ')}`);
+            console.log(`REMOVED_USERNAMES=${removedUsernames.join(', ')}`);

--- a/.github/workflows/update-maintainers.yml
+++ b/.github/workflows/update-maintainers.yml
@@ -7,7 +7,7 @@ on:
       - 'CODEOWNERS'
 
 jobs:
-  compare-codeowners:
+  update-maintainers:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
 

--- a/.github/workflows/update-maintainers.yml
+++ b/.github/workflows/update-maintainers.yml
@@ -80,6 +80,11 @@ jobs:
 
             // Update for added usernames
             addedUsernames.forEach(username => {
+              // Exclude bot accounts
+              if (username === 'asyncapi-bot' || username === 'asyncapi-bot-eve') {
+                console.log('Skipping bot account:', username);
+                return; // Skip the iteration for bot accounts
+              }
               const existingMaintainer = maintainers.find(maintainer => maintainer.github === username);
               if (!existingMaintainer) {
                 maintainers.push({

--- a/.github/workflows/update-maintainers.yml
+++ b/.github/workflows/update-maintainers.yml
@@ -102,10 +102,22 @@ jobs:
             removedUsernames.forEach(username => {
               const index = maintainers.findIndex(maintainer => maintainer.github === username);
               if (index !== -1) {
-                maintainers.splice(index, 1);
-                console.log('Removed maintainer:', username);
+                const maintainer = maintainers[index];
+                const repoIndex = maintainer.repos.indexOf(repoName);
+            
+                if (repoIndex !== -1) {
+                  maintainer.repos.splice(repoIndex, 1);
+                  console.log(`Removed repository ${repoName} from maintainer ${username}`);
+            
+                  if (maintainer.repos.length === 0) {
+                    maintainers.splice(index, 1);
+                    console.log(`Removed maintainer ${username} as they have no other repositories`);
+                  }
+                } else {
+                  console.log(`Repository ${repoName} not found for maintainer ${username}`);
+                }
               } else {
-                console.log('Maintainer', username, 'does not exist. Skipping removal.');
+                console.log(`Maintainer ${username} does not exist. Skipping removal.`);
               }
             });
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This PR updates the MAINTAINERS.yaml file based on the changes made in the CODEOWNERS file. The workflow takes the repository name as input and adds it to the MAINTAINERS.yaml file. When a new code owner is added, a corresponding maintainer object is created in the MAINTAINERS.yaml file with the repository name added to the object. 
Similarly, when a code owner is removed, the corresponding maintainer object is removed from the MAINTAINERS.yaml file. The removal process checks if the maintainer has any other repositories before removing them from the MAINTAINERS.yaml file.

I have tested this workflow on my testRepo by adding a new code owner, and the MAINTAINERS.yaml file was updated with the new code owner object and repository name. Here are the logs from the workflow: https://github.com/14Richa/testRepo/actions/runs/5529240136/jobs/10087030814
Similarly, when a code owner is removed MAINTAINERS.yaml file was updated accordingly with the maintainer object removed from the file. Here are the logs from the workflow: https://github.com/14Richa/testRepo/actions/runs/5529277200/jobs/10087118152

