### PR TITLE
refactor: automate invitation of new maintainers to organization (asyncapi) and team (maintainers)

### DIFF
--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -185,7 +185,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           github-token: ${{ env.GH_TOKEN }}
-           script: |
+          script: |
               const removedMaintainers = "${{ needs.remove_maintainer.outputs.removedMaintainers }}".split(",");
               const removedTscMembers = "${{ needs.remove_maintainer.outputs.removedTscMembers }}".split(",");
 

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -193,15 +193,18 @@ jobs:
               const removedTscMembers = "${{ needs.remove_maintainer.outputs.removedTscMembers }}".split(",");
 
               // Goodbye message to removed maintainers and notification to TSC members
-              const combinedMessage = removedMaintainers.map((maintainer) => {
+              const combinedMessages = removedMaintainers.map((maintainer) => {
                 const tscNotification = removedTscMembers.includes(maintainer)
                   ? `@asyncapi/tsc_members We want to inform you that @${maintainer.trim().replace(/^@/, '')} is no longer a maintainer of any repository under AsyncAPI Initiative. It means this maintainer is also no longer a member of TSC.`
                   : '';
                 return `@${maintainer.trim().replace(/^@/, '')} We wanted to express our gratitude for your contributions as a maintainer of AsyncAPI Initiative. Your efforts have been immensely valuable to us, and we truly appreciate your dedication. Thank you once again, and we wish you all the best in your future endeavors!\n\n${tscNotification}`;
+              });
 
               const { owner, repo } = context.repo;
               const { number: issue_number } = context.issue;
-              return github.rest.issues.createComment({ owner, repo, issue_number, body: combinedMessage });
+              for (const message of combinedMessages) {
+                  github.rest.issues.createComment({ owner, repo, issue_number, body: message });
+              }
 
 
   update_emeritus:

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -49,24 +49,15 @@ jobs:
               (oldObj) => !previousMaintainers.some((newObj) => newObj.github === oldObj.github)
             );
 
-            // Collect information about TSC membership for added maintainers
-            const addedWithTSC = added.map((maintainer) => {
-              const tscMember = currentMaintainers.find((m) => m.github === maintainer.github);
-              return { ...maintainer, isTscMember: tscMember ? tscMember.isTscMember : false };
-            });
-
-            // Store the added maintainers along with their TSC membership status in the outputs
-            if (addedWithTSC.length > 0) {
-              core.info(`Added Maintainer:\n${yaml.dump(addedWithTSC)}`);
-              core.setOutput("newMaintainers", addedWithTSC.map((obj) => obj.github).join(","));
+            if (added.length > 0) {
+              core.setOutput("newMaintainers", added.map((obj) => obj.github).join(","));
             }
-
             if (removed.length > 0) {
               core.setOutput("removedMaintainers", removed.map((obj) => obj.github).join(","));
             }
 
             const removedTscMembers = pr_file.filter(
-              (obj) => !main_file.some((mainObj) => mainObj.github === obj.github) && obj.isTscMember === true
+              (obj) => !currentMaintainers.some((mainObj) => mainObj.github === obj.github) && obj.isTscMember === true
             );
 
             if (removedTscMembers.length > 0) {
@@ -149,23 +140,12 @@ jobs:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const newMaintainers = "${{ needs.add_maintainer.outputs.newMaintainers }}".split(",");
-            const welcomeMessage = newMaintainers.map((maintainer) => {
-              const isTscMember = maintainer.isTscMember;
-              if (isTscMember)) {
-                // Welcome message for TSC members
-                return `@${maintainer.github.trim().replace(/^@/, '')} Welcome to the TSC Members' Club, you are now a member of the exclusive TSC Members team.
-                    We use this team to mention in different discussions in different places on GitHub where Maintainer's opinion is needed or even voting on some topic. Once Maintainers are mentioned:
-                    -  You will receive GitHub notifications.
-                    -  We will also send notifications to our Slack channel #95_bot-maintainers-mentioned.
-                    -  Subscribers to Maintainer news at https://www.asyncapi.com/community/maintainers will receive email notifications.`;
-              } else {
-                // Welcome message for non-TSC members
-                return `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization, and you are added to the team that lists all Maintainers.
+            console.log(`New maintainers: ${newMaintainers}`);
+            const welcomeMessage = newMaintainers.map((maintainer) => `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization, and you are added to the team that lists all Maintainers.
                       Please take a moment to verify if you would like to provide more details for your account, such as your LinkedIn profile, Twitter handle, or company affiliation. 
                       Additionally, if you are interested in becoming a TSC member and contributing to the direction of the AsyncAPI Initiative, let us know, and we'll be happy to guide you through the process.
-                      Welcome aboard! We are excited to have you as part of the team.`;
-                }
-            }).join("\n");
+                      Welcome aboard! We are excited to have you as part of the team.`).join("\n");
+            
             const { owner, repo } = context.repo;
             const { number: issue_number } = context.issue;
             return github.rest.issues.createComment({ owner, repo, issue_number, body: welcomeMessage });

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -124,16 +124,29 @@ jobs:
     if: needs.add_maintainer.outputs.newMaintainers != ''
     runs-on: ubuntu-latest
     steps:
-      - name: Display welcome message
+      - name: Display welcome message for new maintainers
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const newMaintainers = "${{ needs.add_maintainer.outputs.newMaintainers }}".split(",");
-            const welcomeMessage = newMaintainers.map((maintainer) => `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization, and you are added to the team that lists all Maintainers.
-            We use this team to mention in different discussions in various places on GitHub where Maintainer's opinion is needed. Once Maintainers are mentioned:
-            - You will receive GitHub notifications.
-            Welcome aboard! We are excited to have you as part of the team.`).join("\n");
+            const welcomeMessage = newMaintainers.map((maintainer) => {
+              if (maintainer.isTscMember) {
+                // Welcome message for TSC members
+                return `@${maintainer.github.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization and you will soon be added to the team that lists all Maintainers.
+                We use this team to mention in different discussions in different places on GitHub where Maintainer's opinion is needed or even voting on some topic. Once Maintainers are mentioned:
+                - You get GitHub notification
+                - We also drop notification in our slack in #95_bot-maintainers-mentioned channel
+                - We drop an email to people that subscribed to Maintainer news here https://www.asyncapi.com/community/maintainers
+                Pick the channel for notifications that you prefer. Welcome aboard! We are excited to have you as part of the team.`;
+              } else {
+                // Welcome message for non-TSC members
+                return `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization, and you are added to the team that lists all Maintainers.
+                      We use this team to mention in different discussions in various places on GitHub where Maintainer's opinion is needed. Once Maintainers are mentioned:
+                      - You will receive GitHub notifications.
+                      Welcome aboard! We are excited to have you as part of the team.`;
+                }
+            }).join("\n");
             const { owner, repo } = context.repo;
             const { number: issue_number } = context.issue;
             return github.rest.issues.createComment({ owner, repo, issue_number, body: welcomeMessage });

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -253,7 +253,7 @@ jobs:
 
   notify_slack_on_failure:
     if: always() && (needs.detect_maintainer_changes.result == 'failure' || needs.add_maintainer.result == 'failure' || needs.display_message.result == 'failure' || needs.remove_maintainer.result == 'failure' || needs.update_emeritus.result == 'failure' )
-    needs: [detect_maintainer_changes, add_maintainer.result, display_message, remove_maintainer, update_emeritus]
+    needs: [detect_maintainer_changes, add_maintainer.result, display_message, remove_maintainer,remove_maintainer_goodbye, update_emeritus]
     runs-on: ubuntu-latest
     steps:
     - name: Report workflow run status to Slack

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -176,6 +176,31 @@ jobs:
       removedMaintainers: ${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}
       removedTscMembers: ${{ needs.detect_maintainer_changes.outputs.removedTscMembers }}
 
+  remove_maintainer_goodbye:
+    needs: remove_maintainer
+    if: needs.remove_maintainer.outputs.removedMaintainers != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Display goodbye message to removed maintainers
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ env.GH_TOKEN }}
+           script: |
+              const removedMaintainers = "${{ needs.remove_maintainer.outputs.removedMaintainers }}".split(",");
+              const removedTscMembers = "${{ needs.remove_maintainer.outputs.removedTscMembers }}".split(",");
+
+              // Goodbye message to removed maintainers and notification to TSC members
+              const combinedMessage = removedMaintainers.map((maintainer) => {
+                const tscNotification = removedTscMembers.includes(maintainer)
+                  ? `We want to inform you that a TSC member has decided to step down from their role as a maintainer. Their contributions have been valuable to AsyncAPI Initiative , and we are grateful for their efforts.`
+                  : '';
+                return `@${maintainer.trim().replace(/^@/, '')} We wanted to express our gratitude for your contributions as a maintainer to our project. Your efforts have been immensely valuable to us, and we truly appreciate your dedication. Thank you once again, and we wish you all the best in your future endeavors!\n\n${tscNotification}`;
+              }).join('\n');
+
+              const { owner, repo } = context.repo;
+              const { number: issue_number } = context.issue;
+              return github.rest.issues.createComment({ owner, repo, issue_number, body: combinedMessage });
+
 
   update_emeritus:
     needs: detect_maintainer_changes

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -210,7 +210,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Add TSC members to Emeritus.yaml and print
         uses: actions/github-script@v6

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -60,7 +60,7 @@ jobs:
               core.info(`Added Maintainer:\n${yaml.dump(addedWithTSC)}`);
               core.setOutput("newMaintainers", addedWithTSC.map((obj) => obj.github).join(","));
             }
-            
+
             if (removed.length > 0) {
               core.setOutput("removedMaintainers", removed.map((obj) => obj.github).join(","));
             }
@@ -203,7 +203,7 @@ jobs:
 
   update_emeritus:
     needs: remove_maintainer
-    if: needs.detect_maintainer_changes.outputs.removedMaintainers != ''
+    if: needs.remove_maintainer.outputs.removedMaintainers != ''
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -198,7 +198,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Add maintainers to Emeritus.yaml and print
         uses: actions/github-script@v6

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -171,23 +171,7 @@ jobs:
                 core.setFailed(`Failed to remove ${maintainer} from the organization: ${error.message}`);
               }
             }
-
-      - name: Remove maintainers from the team
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ env.GH_TOKEN }}
-          script: |
-            const removedMaintainers = '${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}'.split(',');
-            for (const maintainer of removedMaintainers) {
-              try {
-                await github.request('DELETE /orgs/asyncapi/teams/maintainers/memberships/{username}', {
-                  username: maintainer
-                });
-                core.info(`Successfully removed ${maintainer} from the team.`);
-              } catch (error) {
-                core.setFailed(`Failed to remove ${maintainer} from the team: ${error.message}`);
-              }
-            }
+            
     outputs:
       removedMaintainers: ${{ needs.welcome.outputs.removedMaintainers }}
 

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -207,10 +207,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
-      - name: Add TSC maintainers to Emeritus.yaml and print
-        id: add_emeritus
+      - name: Add maintainers to Emeritus.yaml and print
         uses: actions/github-script@v6
         with:
           github-token: ${{ env.GH_TOKEN }}
@@ -221,26 +220,17 @@ jobs:
             // Read the current content of the file
             let content = fs.readFileSync(path, 'utf8').trim(); // remove any trailing whitespaces
   
-            // Get the list of maintainers from the maintainers.yaml file
-            const maintainers = ${JSON.stringify(yaml.safeLoad(fs.readFileSync('./maintainers.yaml', 'utf8')))};
-
-            // Get the list of removed maintainers from the previous step's output and split them
-            const removedMaintainers = "${{ needs.remove_maintainer.outputs.removedMaintainers }}".split(',');
-
-            // Filter out non-TSC members from the list of removed maintainers
-            const tscMaintainers = removedMaintainers.filter(maintainer => maintainers[maintainer.trim()] && maintainers[maintainer.trim()].isTscMember);
-      
-            // Prepare the TSC maintainers for the yaml format
-            const tscMaintainersYaml = tscMaintainers.map(maintainer => `  - ${maintainer.trim()}`).join('\n');
-      
-            // Append the TSC maintainers to the file content
-            content = content + '\n' + tscMaintainersYaml;
+            // Split the removed maintainers and prepare them for the yaml format
+            const removedMaintainers = "${{ needs.remove_maintainer.outputs.removedMaintainers }}".split(',').map(maintainer => `  - ${maintainer.trim()}`).join('\n');
+  
+            // Append the removed maintainers to the file content
+            content = content + '\n' + removedMaintainers;
   
             // Write the updated content back to the file
             fs.writeFileSync(path, content);
   
-            // Log the updated content using core.info
-            core.info(`Updated Emeritus.yaml:\n${content}`);
+            // Log the updated content to the console
+            core.info('Updated Emeritus.yaml:\n', content);
       
       - name: Create new branch
         run: |

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -65,6 +65,15 @@ jobs:
               core.setOutput("removedMaintainers", removed.map((obj) => obj.github).join(","));
             }
 
+            const removedTscMembers = pr_file.filter(
+              (obj) => !main_file.some((mainObj) => mainObj.github === obj.github) && obj.isTscMember === true
+            );
+
+            if (removedTscMembers.length > 0) {
+              core.setOutput("removedTscMembers", removedTscMembers.map((obj) => obj.github).join(","));
+              core.info(`Removed TSC Members: ${removedTscMembers.map((obj) => obj.github).join(",")}`);
+            }
+
             // Log information for debugging
             core.info('Maintainers in main branch:\n' + yaml.dump(currentMaintainers));
             core.info('Location of Maintainers in main branch:');
@@ -84,6 +93,7 @@ jobs:
     outputs:
       newMaintainers: ${{ steps.compare-files.outputs.newMaintainers }}
       removedMaintainers: ${{ steps.compare-files.outputs.removedMaintainers }}
+      removedTscMembers: ${{ steps.compare-files.outputs.removedTscMembers }}
 
   add_maintainer:
     needs: detect_maintainer_changes
@@ -202,33 +212,37 @@ jobs:
       removedMaintainers: ${{ needs.welcome.outputs.removedMaintainers }}
 
   update_emeritus:
-    needs: remove_maintainer
-    if: needs.remove_maintainer.outputs.removedMaintainers != ''
+    needs: detect_maintainer_changes
+    if: needs.detect_maintainer_changes.outputs.removedTscMembers != ''
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Add maintainers to Emeritus.yaml and print
+      - name: Add TSC members to Emeritus.yaml and print
         uses: actions/github-script@v6
         with:
           github-token: ${{ env.GH_TOKEN }}
           script: |
             const fs = require('fs');
             const path = './Emeritus.yaml';
-  
+
             // Read the current content of the file
             let content = fs.readFileSync(path, 'utf8').trim(); // remove any trailing whitespaces
-  
+
             // Split the removed maintainers and prepare them for the yaml format
-            const removedMaintainers = "${{ needs.remove_maintainer.outputs.removedMaintainers }}".split(',').map(maintainer => `  - ${maintainer.trim()}`).join('\n');
-  
+            const removedTscMembers = "${{ needs.detect_maintainer_changes.outputs.removedTscMembers }}".split(',')
+              .map(maintainer => `  - ${maintainer.trim()}`)
+              .join('\n');
+
             // Append the removed maintainers to the file content
-            content = content + '\n' + removedMaintainers;
-  
+            if (removedTscMembers) {
+              content = content + '\n' + removedTscMembers;
+            }
+
             // Write the updated content back to the file
             fs.writeFileSync(path, content);
-  
+
             // Log the updated content to the console
             core.info('Updated Emeritus.yaml:\n', content);
       

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -141,11 +141,11 @@ jobs:
           script: |
             const newMaintainers = "${{ needs.add_maintainer.outputs.newMaintainers }}".split(",");
             console.log(`New maintainers: ${newMaintainers}`);
-            const welcomeMessage = newMaintainers.map((maintainer) => `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization, and you are added to the team that lists all Maintainers.
+            const welcomeMessage = newMaintainers.map((maintainer) => `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization, and you are added to the team that lists all Maintainers.\n
             
-                      Please take a moment to verify if you would like to provide more details for your account, such as your LinkedIn profile, Twitter handle, or company affiliation. In case there is anything you want to add, please open up a separate pull request for the \`MAINTAINERS.yaml\` file.
+                      Please take a moment to verify if you would like to provide more details for your account, such as your LinkedIn profile, Twitter handle, or company affiliation. In case there is anything you want to add, please open up a separate pull request for the \`MAINTAINERS.yaml\` file.\n
                       
-                      Additionally, if you are interested in becoming a [TSC member](https://github.com/amadeus4dev-examples/amadeus-async-flight-status) and contributing to the direction of the AsyncAPI Initiative, let us know, and we'll be happy to guide you through the process. Every maintainer has the right to become a TSC member, just open a pull request to modify your entry in \`MAINTAINER.yaml\` file and make sure \`isTscMember\` property is set to \`true\`. You can find some basic information about TSC membership in [this TSC-related guide](https://github.com/asyncapi/community/blob/master/TSC_MEMBERSHIP.md). Feel free to reach out to us for more help by dropping a comment in this pull request, or by asking for help in our Slack.
+                      Additionally, if you are interested in becoming a [TSC member](https://github.com/amadeus4dev-examples/amadeus-async-flight-status) and contributing to the direction of the AsyncAPI Initiative, let us know, and we'll be happy to guide you through the process. Every maintainer has the right to become a TSC member, just open a pull request to modify your entry in \`MAINTAINER.yaml\` file and make sure \`isTscMember\` property is set to \`true\`. You can find some basic information about TSC membership in [this TSC-related guide](https://github.com/asyncapi/community/blob/master/TSC_MEMBERSHIP.md). Feel free to reach out to us for more help by dropping a comment in this pull request, or by asking for help in our Slack.\n
                       
                       Welcome aboard! We are excited to have you as part of the team.`).join("\n");
             

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -49,14 +49,23 @@ jobs:
               (oldObj) => !previousMaintainers.some((newObj) => newObj.github === oldObj.github)
             );
 
-            if(added.length > 0) {
-              core.info(`Added Maintainer:\n${yaml.dump(added)}`);
-              core.setOutput("newMaintainers", added.map((obj) => obj.github).join(","));
+            // Collect information about TSC membership for added maintainers
+            const addedWithTSC = added.map((maintainer) => {
+              const tscMember = currentMaintainers.find((m) => m.github === maintainer.github);
+              return { ...maintainer, isTscMember: tscMember ? tscMember.isTscMember : false };
+            });
+
+            // Store the added maintainers along with their TSC membership status in the outputs
+            if (addedWithTSC.length > 0) {
+              core.info(`Added Maintainer:\n${yaml.dump(addedWithTSC)}`);
+              core.setOutput("newMaintainers", addedWithTSC.map((obj) => obj.github).join(","));
             }
+            
             if (removed.length > 0) {
               core.setOutput("removedMaintainers", removed.map((obj) => obj.github).join(","));
             }
 
+            // Log information for debugging
             core.info('Maintainers in main branch:\n' + yaml.dump(currentMaintainers));
             core.info('Location of Maintainers in main branch:');
             core.info(fs.realpathSync('./community-main/MAINTAINERS.yaml'));
@@ -131,19 +140,19 @@ jobs:
           script: |
             const newMaintainers = "${{ needs.add_maintainer.outputs.newMaintainers }}".split(",");
             const welcomeMessage = newMaintainers.map((maintainer) => {
-              if (maintainer.isTscMember) {
+              const isTscMember = maintainer.isTscMember;
+              if (isTscMember)) {
                 // Welcome message for TSC members
-                return `@${maintainer.github.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization and you will soon be added to the team that lists all Maintainers.
-                We use this team to mention in different discussions in different places on GitHub where Maintainer's opinion is needed or even voting on some topic. Once Maintainers are mentioned:
-                - You get GitHub notification
-                - We also drop notification in our slack in #95_bot-maintainers-mentioned channel
-                - We drop an email to people that subscribed to Maintainer news here https://www.asyncapi.com/community/maintainers
-                Pick the channel for notifications that you prefer. Welcome aboard! We are excited to have you as part of the team.`;
+                return `@${maintainer.github.trim().replace(/^@/, '')} Welcome to the TSC Members' Club, you are now a member of the exclusive TSC Members team.
+                    We use this team to mention in different discussions in different places on GitHub where Maintainer's opinion is needed or even voting on some topic. Once Maintainers are mentioned:
+                    -  You will receive GitHub notifications.
+                    -  We will also send notifications to our Slack channel #95_bot-maintainers-mentioned.
+                    -  Subscribers to Maintainer news at https://www.asyncapi.com/community/maintainers will receive email notifications.`;
               } else {
                 // Welcome message for non-TSC members
                 return `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization, and you are added to the team that lists all Maintainers.
-                      We use this team to mention in different discussions in various places on GitHub where Maintainer's opinion is needed. Once Maintainers are mentioned:
-                      - You will receive GitHub notifications.
+                      Please take a moment to verify if you would like to provide more details for your account, such as your LinkedIn profile, Twitter handle, or company affiliation. 
+                      Additionally, if you are interested in becoming a TSC member and contributing to the direction of the AsyncAPI Initiative, let us know, and we'll be happy to guide you through the process.
                       Welcome aboard! We are excited to have you as part of the team.`;
                 }
             }).join("\n");

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -171,9 +171,11 @@ jobs:
                 core.setFailed(`Failed to remove ${maintainer} from the organization: ${error.message}`);
               }
             }
-            
+
     outputs:
-      removedMaintainers: ${{ needs.welcome.outputs.removedMaintainers }}
+      removedMaintainers: ${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}
+      removedTscMembers: ${{ needs.detect_maintainer_changes.outputs.removedTscMembers }}
+
 
   update_emeritus:
     needs: detect_maintainer_changes

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -195,10 +195,9 @@ jobs:
               // Goodbye message to removed maintainers and notification to TSC members
               const combinedMessage = removedMaintainers.map((maintainer) => {
                 const tscNotification = removedTscMembers.includes(maintainer)
-                  ? `We want to inform you all that a TSC member has decided to step down from their role as a maintainer. Their contributions have been valuable to AsyncAPI Initiative , and we are grateful for their efforts.`
+                  ? `@asyncapi/tsc_members We want to inform you that @${maintainer.trim().replace(/^@/, '')} is no longer a maintainer of any repository under AsyncAPI Initiative. It means this maintainer is also no longer a member of TSC.`
                   : '';
-                return `@${maintainer.trim().replace(/^@/, '')} We wanted to express our gratitude for your contributions as a maintainer to our project. Your efforts have been immensely valuable to us, and we truly appreciate your dedication. Thank you once again, and we wish you all the best in your future endeavors!\n\n${tscNotification}`;
-              }).join('\n');
+                return `@${maintainer.trim().replace(/^@/, '')} We wanted to express our gratitude for your contributions as a maintainer of AsyncAPI Initiative. Your efforts have been immensely valuable to us, and we truly appreciate your dedication. Thank you once again, and we wish you all the best in your future endeavors!\n\n${tscNotification}`;
 
               const { owner, repo } = context.repo;
               const { number: issue_number } = context.issue;

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -192,7 +192,7 @@ jobs:
               // Goodbye message to removed maintainers and notification to TSC members
               const combinedMessage = removedMaintainers.map((maintainer) => {
                 const tscNotification = removedTscMembers.includes(maintainer)
-                  ? `We want to inform you that a TSC member has decided to step down from their role as a maintainer. Their contributions have been valuable to AsyncAPI Initiative , and we are grateful for their efforts.`
+                  ? `We want to inform you all that a TSC member has decided to step down from their role as a maintainer. Their contributions have been valuable to AsyncAPI Initiative , and we are grateful for their efforts.`
                   : '';
                 return `@${maintainer.trim().replace(/^@/, '')} We wanted to express our gratitude for your contributions as a maintainer to our project. Your efforts have been immensely valuable to us, and we truly appreciate your dedication. Thank you once again, and we wish you all the best in your future endeavors!\n\n${tscNotification}`;
               }).join('\n');

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -255,7 +255,7 @@ jobs:
           gh pr create --title "docs(community): update latest emeritus list" --body "Updated Emeritus list is available and this PR introduces changes with latest information about Emeritus" --head update-emeritus-${{ github.run_id }}
 
   notify_slack_on_failure:
-    if: always() && (needs.detect_maintainer_changes.result == 'failure' || needs.add_maintainer.result == 'failure' || needs.display_message.result == 'failure' || needs.remove_maintainer.result == 'failure' || needs.update_emeritus.result == 'failure' )
+    if: always() && (needs.detect_maintainer_changes.result == 'failure' || needs.add_maintainer.result == 'failure' || needs.display_message.result == 'failure' || needs.remove_maintainer.result == 'failure' || needs.update_emeritus.result == 'failure' || needs.remove_maintainer_goodbye.result == 'failure' )
     needs: [detect_maintainer_changes, add_maintainer.result, display_message, remove_maintainer,remove_maintainer_goodbye, update_emeritus]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -200,7 +200,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Add maintainers to Emeritus.yaml and print
+      - name: Add TSC maintainers to Emeritus.yaml and print
+        id: add_emeritus
         uses: actions/github-script@v6
         with:
           github-token: ${{ env.GH_TOKEN }}
@@ -211,11 +212,20 @@ jobs:
             // Read the current content of the file
             let content = fs.readFileSync(path, 'utf8').trim(); // remove any trailing whitespaces
   
-            // Split the removed maintainers and prepare them for the yaml format
-            const removedMaintainers = "${{ needs.remove_maintainer.outputs.removedMaintainers }}".split(',').map(maintainer => `  - ${maintainer.trim()}`).join('\n');
-  
-            // Append the removed maintainers to the file content
-            content = content + '\n' + removedMaintainers;
+            // Get the list of maintainers from the maintainers.yaml file
+            const maintainers = ${JSON.stringify(yaml.safeLoad(fs.readFileSync('./maintainers.yaml', 'utf8')))};
+
+            // Get the list of removed maintainers from the previous step's output and split them
+            const removedMaintainers = "${{ needs.remove_maintainer.outputs.removedMaintainers }}".split(',');
+
+            // Filter out non-TSC members from the list of removed maintainers
+            const tscMaintainers = removedMaintainers.filter(maintainer => maintainers[maintainer.trim()] && maintainers[maintainer.trim()].isTscMember);
+      
+            // Prepare the TSC maintainers for the yaml format
+            const tscMaintainersYaml = tscMaintainers.map(maintainer => `  - ${maintainer.trim()}`).join('\n');
+      
+            // Append the TSC maintainers to the file content
+            content = content + '\n' + tscMaintainersYaml;
   
             // Write the updated content back to the file
             fs.writeFileSync(path, content);

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -142,8 +142,11 @@ jobs:
             const newMaintainers = "${{ needs.add_maintainer.outputs.newMaintainers }}".split(",");
             console.log(`New maintainers: ${newMaintainers}`);
             const welcomeMessage = newMaintainers.map((maintainer) => `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization, and you are added to the team that lists all Maintainers.
-                      Please take a moment to verify if you would like to provide more details for your account, such as your LinkedIn profile, Twitter handle, or company affiliation. 
-                      Additionally, if you are interested in becoming a TSC member and contributing to the direction of the AsyncAPI Initiative, let us know, and we'll be happy to guide you through the process.
+            
+                      Please take a moment to verify if you would like to provide more details for your account, such as your LinkedIn profile, Twitter handle, or company affiliation. In case there is anything you want to add, please open up a separate pull request for the \`MAINTAINERS.yaml\` file.
+                      
+                      Additionally, if you are interested in becoming a [TSC member](https://github.com/amadeus4dev-examples/amadeus-async-flight-status) and contributing to the direction of the AsyncAPI Initiative, let us know, and we'll be happy to guide you through the process. Every maintainer has the right to become a TSC member, just open a pull request to modify your entry in \`MAINTAINER.yaml\` file and make sure \`isTscMember\` property is set to \`true\`. You can find some basic information about TSC membership in [this TSC-related guide](https://github.com/asyncapi/community/blob/master/TSC_MEMBERSHIP.md). Feel free to reach out to us for more help by dropping a comment in this pull request, or by asking for help in our Slack.
+                      
                       Welcome aboard! We are excited to have you as part of the team.`).join("\n");
             
             const { owner, repo } = context.repo;

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -1,4 +1,4 @@
-name: Welcome New Maintainer
+name: Maintainer Management Workflow
 
 on:
   pull_request:

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           IFS=',' read -ra MAINTAINERS <<< "${{ needs.welcome.outputs.removedMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do
-            gh api -X DELETE /orgs/richaOrg/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN"
+            gh api -X DELETE /orgs/asyncapi/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN"
           done
 
       - name: Remove maintainers from the team
@@ -143,5 +143,5 @@ jobs:
         run: |
           IFS=',' read -ra MAINTAINERS <<< "${{ needs.welcome.outputs.removedMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do
-            gh api orgs/richaOrg/teams/maintainers/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN" -X DELETE
+            gh api orgs/asyncapi/teams/maintainers/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN" -X DELETE
           done   

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -94,7 +94,7 @@ jobs:
                   username: maintainer
                 });
               } catch (error) {
-                console.error(`Failed to add ${maintainer} to the organization:`, error);
+                core.setFailed(`Failed to add ${maintainer} to the organization: ${error.message}`);
               }
             }
 
@@ -112,7 +112,7 @@ jobs:
                   username: maintainer
                 });
               } catch (error) {
-                console.error(`Failed to add ${maintainer} to the team:`, error);
+                core.setFailed(`Failed to add ${maintainer} to the team: ${error.message}`);
               }
             }
 
@@ -156,9 +156,9 @@ jobs:
                 await github.request('DELETE /orgs/asyncapi/memberships/{username}', {
                   username: maintainer
                 });
-                console.log(`Successfully removed ${maintainer} from the organization.`);
+                core.info(`Successfully removed ${maintainer} from the organization.`);
               } catch (error) {
-                console.error(`Failed to remove ${maintainer} from the organization:`, error);
+                core.setFailed(`Failed to remove ${maintainer} from the organization: ${error.message}`);
               }
             }
 
@@ -173,9 +173,9 @@ jobs:
                 await github.request('DELETE /orgs/asyncapi/teams/maintainers/memberships/{username}', {
                   username: maintainer
                 });
-                console.log(`Successfully removed ${maintainer} from the team.`);
+                core.info(`Successfully removed ${maintainer} from the team.`);
               } catch (error) {
-                console.error(`Failed to remove ${maintainer} from the team:`, error);
+                core.setFailed(`Failed to remove ${maintainer} from the team: ${error.message}`);
               }
             }
     outputs:
@@ -209,8 +209,8 @@ jobs:
             // Write the updated content back to the file
             fs.writeFileSync(path, content);
   
-            // Log the updated content to the console
-            console.log('Updated Emeritus.yaml:\n', content);
+            // Log the updated content using core.info
+            core.info(`Updated Emeritus.yaml:\n${content}`);
       
       - name: Create new branch
         run: |

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -5,6 +5,8 @@ on:
     types: [closed]
     paths: 
       - 'MAINTAINERS.yaml'
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
   detect_maintainer_changes:
@@ -75,8 +77,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Invite new maintainers to the organization
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.newMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do
@@ -84,8 +84,6 @@ jobs:
           done
 
       - name: Add new maintainers to the team
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.newMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do
@@ -129,8 +127,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove maintainers from the organization
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do
@@ -138,8 +134,6 @@ jobs:
           done
 
       - name: Remove maintainers from the team
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -139,14 +139,6 @@ jobs:
             const { owner, repo } = context.repo;
             const { number: issue_number } = context.issue;
             return github.rest.issues.createComment({ owner, repo, issue_number, body: welcomeMessage });
-      - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
-        name: Report workflow run status to Slack
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{secrets.SLACK_CI_FAIL_NOTIFY}}
-          SLACK_TITLE: 🚨 Welcome new contributor action failed 🚨
-          SLACK_MESSAGE: Failed to post a message to new Maintainer
-          MSG_MINIMAL: true
 
   remove_maintainer:
     needs: detect_maintainer_changes
@@ -219,3 +211,16 @@ jobs:
   
             // Log the updated content to the console
             console.log('Updated Emeritus.yaml:\n', content);
+
+  notify_slack_on_failure:
+    if: always() && (needs.detect_maintainer_changes.result == 'failure' || needs.add_maintainer.result == 'failure' || needs.display_message.result == 'failure' || needs.remove_maintainer.result == 'failure' || needs.update_emeritus.result == 'failure' )
+    needs: [detect_maintainer_changes, add_maintainer.result, display_message, remove_maintainer, update_emeritus]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Report workflow run status to Slack
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_WEBHOOK: ${{secrets.SLACK_CI_FAIL_NOTIFY}}
+        SLACK_TITLE: 🚨 Welcome new contributor action failed 🚨
+        SLACK_MESSAGE: Failed to post a message to new Maintainer
+        MSG_MINIMAL: true

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -7,7 +7,7 @@ on:
       - 'MAINTAINERS.yaml'
 
 jobs:
-  welcome:
+  detect_maintainer_changes:
     if: github.event.pull_request.merged 
     runs-on: ubuntu-latest
     steps: 
@@ -72,15 +72,15 @@ jobs:
       removedMaintainers: ${{ steps.compare-files.outputs.removedMaintainers }}
 
   add_maintainer:
-    needs: welcome
-    if: needs.welcome.outputs.newMaintainers != ''
+    needs: detect_maintainer_changes
+    if: needs.detect_maintainer_changes.outputs.newMaintainers != ''
     runs-on: ubuntu-latest
     steps:
       - name: Invite new maintainers to the organization
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          IFS=',' read -ra MAINTAINERS <<< "${{ needs.welcome.outputs.newMaintainers }}"
+          IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.newMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do
             gh api -X PUT /orgs/asyncapi/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN"
           done
@@ -89,16 +89,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          IFS=',' read -ra MAINTAINERS <<< "${{ needs.welcome.outputs.newMaintainers }}"
+          IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.newMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do
             gh api orgs/asyncapi/teams/maintainers/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN" -X PUT
           done
     outputs:
-      newMaintainers: ${{needs.welcome.outputs.newMaintainers }}
+      newMaintainers: ${{needs.detect_maintainer_changes.outputs.newMaintainers }}
 
   display_message:
     needs: add_maintainer
-    if: needs.welcome.outputs.newMaintainers != ''
+    if: needs.detect_maintainer_changes.outputs.newMaintainers != ''
     runs-on: ubuntu-latest
     steps:
       - name: Display welcome message
@@ -126,15 +126,15 @@ jobs:
           MSG_MINIMAL: true
 
   remove_maintainer:
-    needs: welcome
-    if: needs.welcome.outputs.removedMaintainers != ''
+    needs: detect_maintainer_changes
+    if: needs.detect_maintainer_changes.outputs.removedMaintainers != ''
     runs-on: ubuntu-latest
     steps:
       - name: Remove maintainers from the organization
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          IFS=',' read -ra MAINTAINERS <<< "${{ needs.welcome.outputs.removedMaintainers }}"
+          IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do
             gh api -X DELETE /orgs/asyncapi/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN"
           done
@@ -143,7 +143,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          IFS=',' read -ra MAINTAINERS <<< "${{ needs.welcome.outputs.removedMaintainers }}"
+          IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do
             gh api orgs/asyncapi/teams/maintainers/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN" -X DELETE
           done   

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -181,3 +181,36 @@ jobs:
                 console.error(`Failed to remove ${maintainer} from the team:`, error);
               }
             }
+    outputs:
+      removedMaintainers: ${{ needs.welcome.outputs.removedMaintainers }}
+
+  update_emeritus:
+    needs: remove_maintainer
+    if: needs.detect_maintainer_changes.outputs.removedMaintainers != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Add maintainers to Emeritus.yaml and print
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ env.GH_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = './Emeritus.yaml';
+  
+            // Read the current content of the file
+            let content = fs.readFileSync(path, 'utf8').trim(); // remove any trailing whitespaces
+  
+            // Split the removed maintainers and prepare them for the yaml format
+            const removedMaintainers = "${{ needs.remove_maintainer.outputs.removedMaintainers }}".split(',').map(maintainer => `  - ${maintainer.trim()}`).join('\n');
+  
+            // Append the removed maintainers to the file content
+            content = content + '\n' + removedMaintainers;
+  
+            // Write the updated content back to the file
+            fs.writeFileSync(path, content);
+  
+            // Log the updated content to the console
+            console.log('Updated Emeritus.yaml:\n', content);

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -130,12 +130,10 @@ jobs:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const newMaintainers = "${{ needs.add_maintainer.outputs.newMaintainers }}".split(",");
-            const welcomeMessage = newMaintainers.map((maintainer) => `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization and you are added to the team that lists all Maintainers.
-            We use this team to mention in different discussions in different places in GitHub where Maintainer's opinion is needed or even voting on some topic. Once Maintainers are mentioned:
-            - You get GitHub notification
-            - We also drop notification in our slack in #95_bot-maintainers-mentioned channel
-            - We drop an email to people that subscribed to Maintainer news here https://www.asyncapi.com/community/maintainers
-            Pick the channel for notifications that you prefer. Welcome aboard! We are excited to have you as part of the team.`).join("\n");
+            const welcomeMessage = newMaintainers.map((maintainer) => `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization, and you are added to the team that lists all Maintainers.
+            We use this team to mention in different discussions in various places on GitHub where Maintainer's opinion is needed. Once Maintainers are mentioned:
+            - You will receive GitHub notifications.
+            Welcome aboard! We are excited to have you as part of the team.`).join("\n");
             const { owner, repo } = context.repo;
             const { number: issue_number } = context.issue;
             return github.rest.issues.createComment({ owner, repo, issue_number, body: welcomeMessage });

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -37,28 +37,28 @@ jobs:
             const fs = require("fs");
             const yaml = require('js-yaml');
 
-            const main_file = yaml.load(fs.readFileSync('./community-main/MAINTAINERS.yaml', 'utf8'));
-            const pr_file = yaml.load(fs.readFileSync('./community/MAINTAINERS.yaml', 'utf8'));
+            const currentMaintainers = yaml.load(fs.readFileSync('./community-main/MAINTAINERS.yaml', 'utf8'));
+            const previousMaintainers = yaml.load(fs.readFileSync('./community/MAINTAINERS.yaml', 'utf8'));
 
-            const removed = pr_file.filter(
-              (newObj) => !main_file.some((oldObj) => oldObj.github === newObj.github)
+            const removed = previousMaintainers.filter(
+              (newObj) => !currentMaintainers.some((oldObj) => oldObj.github === newObj.github)
             );
-            const added = main_file.filter(
-              (oldObj) => !pr_file.some((newObj) => newObj.github === oldObj.github)
+            const added = currentMaintainers.filter(
+              (oldObj) => !previousMaintainers.some((newObj) => newObj.github === oldObj.github)
             );
 
             if(added.length > 0) {
               core.info(`Added Contributors:\n${yaml.dump(added)}`);
               core.setOutput("newContributors", added.map((obj) => obj.github).join(","));
             }
-             if (removed.length > 0) {
+            if (removed.length > 0) {
               core.setOutput("removedMaintainers", removed.map((obj) => obj.github).join(","));
             }
 
-            core.info('Maintainers in main branch:\n' + yaml.dump(main_file));
+            core.info('Maintainers in main branch:\n' + yaml.dump(currentMaintainers));
             core.info('Location of Maintainers in main branch:');
             core.info(fs.realpathSync('./community-main/MAINTAINERS.yaml'));
-            core.info('Maintainers in PR branch:\n' + yaml.dump(pr_file));
+            core.info('Maintainers in PR branch:\n' + yaml.dump(previousMaintainers));
             core.info('Location of Maintainers in PR branch:');
             core.info(fs.realpathSync('./community/MAINTAINERS.yaml'));
 

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -1,4 +1,4 @@
-name: Welcome New Contributor
+name: Welcome New Maintainer
 
 on:
   pull_request:

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -37,14 +37,16 @@ jobs:
             const fs = require("fs");
             const yaml = require('js-yaml');
 
-            const main_file = yaml.load('./community-main/MAINTAINERS.yaml', 'utf8');
-            const pr_file = yaml.load('./community/MAINTAINERS.yaml', 'utf8');
+            const main_file = yaml.load(fs.readFileSync('./community-main/MAINTAINERS.yaml', 'utf8'));
+            const main_file = yaml.load(fs.readFileSync('./community/MAINTAINERS.yaml', 'utf8'));
+
             const removed = pr_file.filter(
               (newObj) => !main_file.some((oldObj) => oldObj.github === newObj.github)
             );
             const added = main_file.filter(
               (oldObj) => !pr_file.some((newObj) => newObj.github === oldObj.github)
             );
+
             if(added.length > 0) {
               core.info(`Added Contributors:\n${yaml.dump(added)}`);
               core.setOutput("newContributors", added.map((obj) => obj.github).join(","));
@@ -53,6 +55,7 @@ jobs:
               core.info(`Removed Contributors:\n${yaml.dump(removed)}`);
               core.setOutput("removed", "true");
             }
+
             core.info('Maintainers in main branch:\n' + yaml.dump(main_file));
             core.info('Location of Maintainers in main branch:');
             core.info(fs.realpathSync('./community-main/MAINTAINERS.yaml'));
@@ -65,8 +68,38 @@ jobs:
       - name: Debug newMaintainers output
         run: |
           echo "newMaintainers = $newMaintainers"
+    outputs:
+      newMaintainers: ${{ steps.compare-files.outputs.newMaintainers }}
+
+  add_maintainer:
+    needs: welcome
+    if: needs.welcome.outputs.newMaintainers != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invite new maintainers to the organization
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IFS=',' read -ra MAINTAINERS <<< "${{ needs.welcome.outputs.newMaintainers }}"
+          for MAINTAINER in "${MAINTAINERS[@]}"; do
+            gh api -X PUT /orgs/asyncapi/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN"
+          done
+
+      - name: Add new maintainers to the team
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IFS=',' read -ra MAINTAINERS <<< "${{ needs.welcome.outputs.newMaintainers }}"
+          for MAINTAINER in "${MAINTAINERS[@]}"; do
+            gh api orgs/asyncapi/teams/maintainers/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN" -X PUT
+          done
+
+  display_message:
+    needs: add_maintainer
+    if: needs.welcome.outputs.newMaintainers != ''
+    runs-on: ubuntu-latest
+    steps:
       - name: Display welcome message
-        if: env.newMaintainers != ''
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -38,7 +38,7 @@ jobs:
             const yaml = require('js-yaml');
 
             const main_file = yaml.load(fs.readFileSync('./community-main/MAINTAINERS.yaml', 'utf8'));
-            const main_file = yaml.load(fs.readFileSync('./community/MAINTAINERS.yaml', 'utf8'));
+            const pr_file = yaml.load(fs.readFileSync('./community/MAINTAINERS.yaml', 'utf8'));
 
             const removed = pr_file.filter(
               (newObj) => !main_file.some((oldObj) => oldObj.github === newObj.github)

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -78,27 +78,39 @@ jobs:
     steps:
       - name: Invite new maintainers to the organization
         uses: actions/github-script@v6
-        with: 
+        with:
+          github-token: ${{ env.GH_TOKEN }}
           script: |
-            const { execSync } = require('child_process');
             const newMaintainers = '${{ needs.detect_maintainer_changes.outputs.newMaintainers }}'.split(',');
-            const token = process.env.GH_TOKEN;
-  
             for (const maintainer of newMaintainers) {
-              execSync(`gh api -X PUT /orgs/asyncapi/memberships/${maintainer} -H "Authorization: token ${token}"`);
+              try {
+                await github.request('PUT /orgs/{org}/memberships/{username}', {
+                  org: 'asyncapi',
+                  username: maintainer
+                });
+              } catch (error) {
+                console.error(`Failed to add ${maintainer} to the organization:`, error);
+              }
             }
 
       - name: Add new maintainers to the team
         uses: actions/github-script@v6
-        with: 
+        with:
+          github-token: ${{ env.GH_TOKEN }}
           script: |
-            const { execSync } = require('child_process');
             const newMaintainers = '${{ needs.detect_maintainer_changes.outputs.newMaintainers }}'.split(',');
-            const token = process.env.GH_TOKEN;
-
             for (const maintainer of newMaintainers) {
-              execSync(`gh api -X PUT orgs/asyncapi/teams/maintainers/memberships/${maintainer} -H "Authorization: token ${token}"`);
+              try {
+                await github.request('PUT /orgs/{org}/teams/{team_slug}/memberships/{username}', {
+                  org: 'asyncapi',
+                  team_slug: 'maintainers',
+                  username: maintainer
+                });
+              } catch (error) {
+                console.error(`Failed to add ${maintainer} to the team:`, error);
+              }
             }
+
     outputs:
       newMaintainers: ${{needs.detect_maintainer_changes.outputs.newMaintainers }}
 

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -93,6 +93,8 @@ jobs:
           for MAINTAINER in "${MAINTAINERS[@]}"; do
             gh api orgs/asyncapi/teams/maintainers/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN" -X PUT
           done
+    outputs:
+      newMaintainers: ${{needs.welcome.outputs.newMaintainers }}
 
   display_message:
     needs: add_maintainer
@@ -104,7 +106,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const newMaintainers = process.env.newMaintainers.split(",");
+            const newMaintainers = "${{ needs.add_maintainer.outputs.newMaintainers }}".split(",");
             const welcomeMessage = newMaintainers.map((maintainer) => `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization and you will soon be added to the team that lists all Maintainers.
             We use this team to mention in different discussions in different places in GitHub where Maintainer's opinion is needed or even voting on some topic. Once Maintainers are mentioned:
             - You get GitHub notification

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -77,18 +77,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Invite new maintainers to the organization
-        run: |
-          IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.newMaintainers }}"
-          for MAINTAINER in "${MAINTAINERS[@]}"; do
-            gh api -X PUT /orgs/asyncapi/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN"
-          done
+        uses: actions/github-script@v6
+        with: 
+          script: |
+            const { execSync } = require('child_process');
+            const newMaintainers = '${{ needs.welcome.outputs.newMaintainers }}'.split(',');
+            const token = process.env.GH_TOKEN;
+  
+            for (const maintainer of newMaintainers) {
+              execSync(`gh api -X PUT /orgs/asyncapi/memberships/${maintainer} -H "Authorization: token ${token}"`);
+            }
 
       - name: Add new maintainers to the team
-        run: |
-          IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.newMaintainers }}"
-          for MAINTAINER in "${MAINTAINERS[@]}"; do
-            gh api orgs/asyncapi/teams/maintainers/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN" -X PUT
-          done
+        uses: actions/github-script@v6
+        with: 
+          script: |
+            const { execSync } = require('child_process');
+            const newMaintainers = '${{ needs.welcome.outputs.newMaintainers }}'.split(',');
+            const token = process.env.GH_TOKEN;
+
+            for (const maintainer of newMaintainers) {
+              execSync(`gh api -X PUT orgs/asyncapi/teams/maintainers/memberships/${maintainer} -H "Authorization: token ${token}"`);
+            }
     outputs:
       newMaintainers: ${{needs.detect_maintainer_changes.outputs.newMaintainers }}
 

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -48,8 +48,8 @@ jobs:
             );
 
             if(added.length > 0) {
-              core.info(`Added Contributors:\n${yaml.dump(added)}`);
-              core.setOutput("newContributors", added.map((obj) => obj.github).join(","));
+              core.info(`Added Maintainer:\n${yaml.dump(added)}`);
+              core.setOutput("newMaintainers", added.map((obj) => obj.github).join(","));
             }
             if (removed.length > 0) {
               core.setOutput("removedMaintainers", removed.map((obj) => obj.github).join(","));
@@ -62,8 +62,6 @@ jobs:
             core.info('Location of Maintainers in PR branch:');
             core.info(fs.realpathSync('./community/MAINTAINERS.yaml'));
 
-      - name: Set newMaintainers as environment variable
-        run: echo "newMaintainers=${{ steps.compare-files.outputs.newMaintainers }}" >> $GITHUB_ENV
       - name: Debug newMaintainers output
         run: |
           echo "newMaintainers = $newMaintainers"
@@ -78,7 +76,7 @@ jobs:
     steps:
       - name: Invite new maintainers to the organization
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.newMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do
@@ -87,7 +85,7 @@ jobs:
 
       - name: Add new maintainers to the team
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.newMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do
@@ -98,13 +96,13 @@ jobs:
 
   display_message:
     needs: add_maintainer
-    if: needs.detect_maintainer_changes.outputs.newMaintainers != ''
+    if: needs.add_maintainer.outputs.newMaintainers != ''
     runs-on: ubuntu-latest
     steps:
       - name: Display welcome message
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const newMaintainers = "${{ needs.add_maintainer.outputs.newMaintainers }}".split(",");
             const welcomeMessage = newMaintainers.map((maintainer) => `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization and you will soon be added to the team that lists all Maintainers.
@@ -132,7 +130,7 @@ jobs:
     steps:
       - name: Remove maintainers from the organization
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do
@@ -141,7 +139,7 @@ jobs:
 
       - name: Remove maintainers from the team
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}"
           for MAINTAINER in "${MAINTAINERS[@]}"; do

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -150,24 +150,34 @@ jobs:
     steps:
       - name: Remove maintainers from the organization
         uses: actions/github-script@v6
-        with: 
+        with:
+          github-token: ${{ env.GH_TOKEN }}
           script: |
-            const { execSync } = require('child_process');
             const removedMaintainers = '${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}'.split(',');
-            const token = process.env.GH_TOKEN;
-
             for (const maintainer of removedMaintainers) {
-              execSync(`gh api -X DELETE /orgs/asyncapi/memberships/${maintainer} -H "Authorization: token ${token}"`);
+              try {
+                await github.request('DELETE /orgs/asyncapi/memberships/{username}', {
+                  username: maintainer
+                });
+                console.log(`Successfully removed ${maintainer} from the organization.`);
+              } catch (error) {
+                console.error(`Failed to remove ${maintainer} from the organization:`, error);
+              }
             }
 
       - name: Remove maintainers from the team
         uses: actions/github-script@v6
         with:
+          github-token: ${{ env.GH_TOKEN }}
           script: |
-            const { execSync } = require('child_process');
             const removedMaintainers = '${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}'.split(',');
-            const token = process.env.GH_TOKEN;
-
             for (const maintainer of removedMaintainers) {
-              execSync(`gh api -X DELETE orgs/asyncapi/teams/maintainers/memberships/${maintainer} -H "Authorization: token ${token}"`);
+              try {
+                await github.request('DELETE /orgs/asyncapi/teams/maintainers/memberships/{username}', {
+                  username: maintainer
+                });
+                console.log(`Successfully removed ${maintainer} from the team.`);
+              } catch (error) {
+                console.error(`Failed to remove ${maintainer} from the team:`, error);
+              }
             }

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -211,6 +211,20 @@ jobs:
   
             // Log the updated content to the console
             console.log('Updated Emeritus.yaml:\n', content);
+      
+      - name: Create new branch
+        run: |
+          git checkout -b update-emeritus-${{ github.run_id }}
+
+      - name: Commit and push
+        run: |
+          git add .
+          git commit -m "Update Emeritus.yaml"
+          git push https://${{ secrets.GH_TOKEN}}@github.com/asyncapi/community update-emeritus-${{ github.run_id }}
+
+      - name: Create PR
+        run: |
+          gh pr create --title "docs(community): update latest emeritus list" --body "Updated Emeritus list is available and this PR introduces changes with latest information about Emeritus" --head update-emeritus-${{ github.run_id }}
 
   notify_slack_on_failure:
     if: always() && (needs.detect_maintainer_changes.result == 'failure' || needs.add_maintainer.result == 'failure' || needs.display_message.result == 'failure' || needs.remove_maintainer.result == 'failure' || needs.update_emeritus.result == 'failure' )

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -51,9 +51,8 @@ jobs:
               core.info(`Added Contributors:\n${yaml.dump(added)}`);
               core.setOutput("newContributors", added.map((obj) => obj.github).join(","));
             }
-            if(removed.length > 0) {
-              core.info(`Removed Contributors:\n${yaml.dump(removed)}`);
-              core.setOutput("removed", "true");
+             if (removed.length > 0) {
+              core.setOutput("removedMaintainers", removed.map((obj) => obj.github).join(","));
             }
 
             core.info('Maintainers in main branch:\n' + yaml.dump(main_file));
@@ -70,6 +69,7 @@ jobs:
           echo "newMaintainers = $newMaintainers"
     outputs:
       newMaintainers: ${{ steps.compare-files.outputs.newMaintainers }}
+      removedMaintainers: ${{ steps.compare-files.outputs.removedMaintainers }}
 
   add_maintainer:
     needs: welcome
@@ -121,4 +121,27 @@ jobs:
           SLACK_WEBHOOK: ${{secrets.SLACK_CI_FAIL_NOTIFY}}
           SLACK_TITLE: 🚨 Welcome new contributor action failed 🚨
           SLACK_MESSAGE: Failed to post a message to new Maintainer
-          MSG_MINIMAL: true     
+          MSG_MINIMAL: true
+
+  remove_maintainer:
+    needs: welcome
+    if: needs.welcome.outputs.removedMaintainers != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove maintainers from the organization
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IFS=',' read -ra MAINTAINERS <<< "${{ needs.welcome.outputs.removedMaintainers }}"
+          for MAINTAINER in "${MAINTAINERS[@]}"; do
+            gh api -X DELETE /orgs/richaOrg/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN"
+          done
+
+      - name: Remove maintainers from the team
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IFS=',' read -ra MAINTAINERS <<< "${{ needs.welcome.outputs.removedMaintainers }}"
+          for MAINTAINER in "${MAINTAINERS[@]}"; do
+            gh api orgs/richaOrg/teams/maintainers/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN" -X DELETE
+          done   

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -67,6 +67,11 @@ jobs:
       - name: Debug newMaintainers output
         run: |
           echo "newMaintainers = $newMaintainers"
+
+      - name: Debug removedMaintainers output
+        run: |
+          echo "removedMaintainers = $removedMaintainers"
+
     outputs:
       newMaintainers: ${{ steps.compare-files.outputs.newMaintainers }}
       removedMaintainers: ${{ steps.compare-files.outputs.removedMaintainers }}

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -81,7 +81,7 @@ jobs:
         with: 
           script: |
             const { execSync } = require('child_process');
-            const newMaintainers = '${{ needs.welcome.outputs.newMaintainers }}'.split(',');
+            const newMaintainers = '${{ needs.detect_maintainer_changes.outputs.newMaintainers }}'.split(',');
             const token = process.env.GH_TOKEN;
   
             for (const maintainer of newMaintainers) {
@@ -93,7 +93,7 @@ jobs:
         with: 
           script: |
             const { execSync } = require('child_process');
-            const newMaintainers = '${{ needs.welcome.outputs.newMaintainers }}'.split(',');
+            const newMaintainers = '${{ needs.detect_maintainer_changes.outputs.newMaintainers }}'.split(',');
             const token = process.env.GH_TOKEN;
 
             for (const maintainer of newMaintainers) {
@@ -137,15 +137,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove maintainers from the organization
-        run: |
-          IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}"
-          for MAINTAINER in "${MAINTAINERS[@]}"; do
-            gh api -X DELETE /orgs/asyncapi/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN"
-          done
+        uses: actions/github-script@v6
+        with: 
+          script: |
+            const { execSync } = require('child_process');
+            const removedMaintainers = '${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}'.split(',');
+            const token = process.env.GH_TOKEN;
+
+            for (const maintainer of removedMaintainers) {
+              execSync(`gh api -X DELETE /orgs/asyncapi/memberships/${maintainer} -H "Authorization: token ${token}"`);
+            }
 
       - name: Remove maintainers from the team
-        run: |
-          IFS=',' read -ra MAINTAINERS <<< "${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}"
-          for MAINTAINER in "${MAINTAINERS[@]}"; do
-            gh api orgs/asyncapi/teams/maintainers/memberships/$MAINTAINER -H "Authorization: token $GH_TOKEN" -X DELETE
-          done   
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const removedMaintainers = '${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}'.split(',');
+            const token = process.env.GH_TOKEN;
+
+            for (const maintainer of removedMaintainers) {
+              execSync(`gh api -X DELETE orgs/asyncapi/teams/maintainers/memberships/${maintainer} -H "Authorization: token ${token}"`);
+            }

--- a/.github/workflows/msg-to-new-member-pr-merged.yml
+++ b/.github/workflows/msg-to-new-member-pr-merged.yml
@@ -130,7 +130,7 @@ jobs:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const newMaintainers = "${{ needs.add_maintainer.outputs.newMaintainers }}".split(",");
-            const welcomeMessage = newMaintainers.map((maintainer) => `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization and you will soon be added to the team that lists all Maintainers.
+            const welcomeMessage = newMaintainers.map((maintainer) => `@${maintainer.trim().replace(/^@/, '')} I have invited you to join the AsyncAPI organization and you are added to the team that lists all Maintainers.
             We use this team to mention in different discussions in different places in GitHub where Maintainer's opinion is needed or even voting on some topic. Once Maintainers are mentioned:
             - You get GitHub notification
             - We also drop notification in our slack in #95_bot-maintainers-mentioned channel


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This PR introduces new jobs to the Welcome New Contributor workflow.

Changes include:

- Added a new job, `add_maintainer`, which invites new maintainers to the organization (ayncapi) and adds them to the team (maintainers). It runs only if new maintainers were identified in the `welcome` job.

- Added a new job `remove_maintainer` which automatically removes maintainers from the organization (asyncapi) and from the maintainers team. This job only runs if removed maintainers are identified.

- Added another job, `display_message`, which posts a welcome message for new maintainers. It depends on the `add_maintainer` job and also only runs if new maintainers were identified.

- Added a job, `update_emeritus` dependent on the `remove_maintainer` job and only runs if `removedMaintainers` output is not empty, updates the `Emeritus.yaml` file by appending the list of removed maintainers in YAML format.

**Testing**
These changes have been tested in a  test repository. The logs indicate that both [add_maintainer](https://github.com/14Richa/testRepo/actions/runs/5563252465) and [remove_maintainer](https://github.com/14Richa/testRepo/actions/runs/5563403262) jobs successfully invited and removed maintainers to/from the organization and team, respectively. 
Furthermore, the display_message job successfully posted a welcome message in the [PR](https://github.com/14Richa/testRepo/pull/463). 