### PR TITLE
ci: checkout of PR branch is not working

### DIFF
--- a/.github/workflows/maintainers-tsc-changes-verification.yaml
+++ b/.github/workflows/maintainers-tsc-changes-verification.yaml
@@ -24,7 +24,8 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           path: pr-branch
 
       - name: Install js-yaml


### PR DESCRIPTION
**Description**

- Adds the repo input also to the checkout actions input.

**Testing the workflow change**
Successful run:- https://github.com/ash17290/asyncapi-community/actions/runs/7657528372

**Related issue(s)**
Fixes #1024 
