### PR TITLE
ci: change event to pull_request_target

### DIFF
--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -1,7 +1,7 @@
 name: Maintainer Management Workflow
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     paths: 
       - 'MAINTAINERS.yaml'

--- a/.github/workflows/maintainers-tsc-changes-verification.yaml
+++ b/.github/workflows/maintainers-tsc-changes-verification.yaml
@@ -1,7 +1,7 @@
 name: Verify tsc and maintainers changes by human and bot
 
 on:
-  pull_request:
+  pull_request_target:
     types: [synchronize, opened, reopened]
     paths:
       - "MAINTAINERS.yaml"

--- a/.github/workflows/tsc_management.yml
+++ b/.github/workflows/tsc_management.yml
@@ -1,7 +1,7 @@
 name: TSC Management Workflow
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     paths:
       - 'MAINTAINERS.yaml'


### PR DESCRIPTION
**Description**

- Related to #1025 
- Changes event to pull_request_target for access to **secrets**

> [!CAUTION]
> As the event is being changed to `pull_request_target` we need to ensure no security vulnerability.

PS:- Can a comment be added with a mention of this?

> [!NOTE]
> This PR should not be merged till the automation workflow is set as it will close the current TSC PRs as seen [here](https://github.com/ash17290/asyncapi-community/pull/5)

**Related issue(s)**
Fixes #1024 