### PR TITLE
feat: add initial DX working group proposal

### DIFF
--- a/WORKING_GROUPS.yaml
+++ b/WORKING_GROUPS.yaml
@@ -12,3 +12,14 @@ working_groups:
   #   okrs_url: https://example.com/xyz # Required. Link to a GitHub project, issue, or any other tool where the Working Group explains their objectives.
   #   roadmap_url: https://example.com/xyz # Recommended. Link to a GitHub project, issue, or any other tool where the Working Group outlines their roadmap.
   #   github_team: # Recommended. The GitHub team handle to tag all the working group members at once. Example: @asyncapi/community_growth_wg.
+  - name: Developer Experience
+    description: The goal of this group is to empower AsyncAPI user journey trough intuitive onboarding, tools, and a frictionless experience.
+    chairperson: @Amzani
+    members:
+      - @KhudaDad414
+      - @peter-rr
+      - @Amzani
+    slack_channel: developer-experience-wg
+    roadmap_url: https://shapeit.app/projects/org/asyncapi/16
+    okrs_url: https://github.com/users/Amzani/projects/12/views/1
+    github_team: @asyncapi/developer_experience_wg

--- a/WORKING_GROUPS.yaml
+++ b/WORKING_GROUPS.yaml
@@ -16,8 +16,12 @@ working_groups:
     description: The goal of this group is to empower AsyncAPI user journey trough intuitive onboarding, tools, and a frictionless experience.
     chairperson: @Amzani
     members:
+      - @Pakisan
       - @KhudaDad414
+      - @ivangsa
       - @peter-rr
+      - @Shurtu-gal
+      - @princerajpoot20
     slack_channel: developer-experience-wg
     roadmap_url: https://shapeit.app/projects/org/asyncapi/16
     okrs_url: https://github.com/users/Amzani/projects/12/views/1

--- a/WORKING_GROUPS.yaml
+++ b/WORKING_GROUPS.yaml
@@ -18,7 +18,6 @@ working_groups:
     members:
       - @KhudaDad414
       - @peter-rr
-      - @Amzani
     slack_channel: developer-experience-wg
     roadmap_url: https://shapeit.app/projects/org/asyncapi/16
     okrs_url: https://github.com/users/Amzani/projects/12/views/1

--- a/WORKING_GROUPS.yaml
+++ b/WORKING_GROUPS.yaml
@@ -13,7 +13,7 @@ working_groups:
   #   roadmap_url: https://example.com/xyz # Recommended. Link to a GitHub project, issue, or any other tool where the Working Group outlines their roadmap.
   #   github_team: # Recommended. The GitHub team handle to tag all the working group members at once. Example: @asyncapi/community_growth_wg.
   - name: Developer Experience
-    description: The goal of this group is to empower AsyncAPI user journey trough intuitive onboarding, tools, and a frictionless experience.
+    description: The goal of the Developer Experience Working Group is to empower the AsyncAPI user journey through intuitive onboarding, tools, and a frictionless experience. 
     chairperson: @Amzani
     members:
       - @Pakisan


### PR DESCRIPTION
Related to https://github.com/orgs/asyncapi/discussions/1037

In addition to @KhudaDad414, @peter-rr, and myself, I suggest additional founding members (please vote by 👍 if you want to join as a funding member)

- @Pakisan: Maintainer of Java bindings and JetBrains IDEA plugin
- @Shurtu-gal: Active contributor in different AsyncAPI projects, and aspiring Studio maintainer
- @princerajpoot20: Studio Design System maintainer
- @ivangsa: Maintainer of [AsyncAPI VS Code extension](https://github.com/asyncapi/vs-asyncapi-preview)

I propose myself as the chairperson (Rotating role) unless there are any objections, I'll be accountable and responsible for the following:

- Manage the overall vision and direction of the working group
- Oversee the development and maintenance of the roadmap
- Mediate conflicts and ensure a positive and safe working atmosphere
- Monitor and maintain Working group goals
- Communicate Working group achievements

## Expectations of founding members & members

- Active participation in the DX working group
- Vote for key decisions (e.g the selection of new members, chairperson rotation ...)
- Influence the working group roadmap
- Assist in the onboarding process for new members
- Provide insights and expertise to enhance the group's effectiveness


## Requirement to join as a member

- Active AsyncAPI contribution (maintainer / aspiring maintainer)
- Past contributions related to the Developer Experience area

 

