### PR TITLE
feat: adding initial Community Growth WG proposal

### DIFF
--- a/WORKING_GROUPS.yaml
+++ b/WORKING_GROUPS.yaml
@@ -33,6 +33,7 @@ working_groups:
       - @AceTheCreator
       - @alequetzalli
       - @smoya
+      - @thulieblack 
     slack_channel: community-growth-wg
     roadmap_url: https://github.com/orgs/asyncapi/projects/33/views/8
     okrs_url: https://github.com/orgs/asyncapi/projects/33/views/12

--- a/WORKING_GROUPS.yaml
+++ b/WORKING_GROUPS.yaml
@@ -12,3 +12,14 @@ working_groups:
   #   okrs_url: https://example.com/xyz # Required. Link to a GitHub project, issue, or any other tool where the Working Group explains their objectives.
   #   roadmap_url: https://example.com/xyz # Recommended. Link to a GitHub project, issue, or any other tool where the Working Group outlines their roadmap.
   #   github_team: # Recommended. The GitHub team handle to tag all the working group members at once. Example: @asyncapi/community_growth_wg.
+ - name: Community Growth
+    description: The goal of this group is making sure the AsyncAPI community grows in a healthy and sustainable way.
+    chairperson: @Barbanio 
+    members:
+      - @AceTheCreator
+      - @alequetzalli
+      - @smoya
+    slack_channel: community-growth-wg
+    roadmap_url: https://github.com/orgs/asyncapi/projects/33/views/8
+    okrs_url: https://github.com/orgs/asyncapi/projects/33/views/12
+    github_team: @asyncapi/community_growth_wg

--- a/WORKING_GROUPS.yaml
+++ b/WORKING_GROUPS.yaml
@@ -32,6 +32,7 @@ working_groups:
     members:
       - @AceTheCreator
       - @alequetzalli
+      - @Mayaleeeee
       - @smoya
       - @thulieblack 
     slack_channel: community-growth-wg

--- a/WORKING_GROUPS.yaml
+++ b/WORKING_GROUPS.yaml
@@ -13,7 +13,7 @@ working_groups:
   #   roadmap_url: https://example.com/xyz # Recommended. Link to a GitHub project, issue, or any other tool where the Working Group outlines their roadmap.
   #   github_team: # Recommended. The GitHub team handle to tag all the working group members at once. Example: @asyncapi/community_growth_wg.
  - name: Community Growth
-    description: The goal of this group is making sure the AsyncAPI community grows in a healthy and sustainable way.
+    description: The Community Working Group aims to ensure AsyncAPI community growth in a healthy and sustainable way.  
     chairperson: @Barbanio 
     members:
       - @AceTheCreator


### PR DESCRIPTION
After incorporating [the working groups](https://github.com/orgs/asyncapi/discussions/1037) as a possible working system in AsyncAPI, @AceTheCreator, @alequetzalli, @smoya, and myself, we propose the creation of the Community Growth working group.

The 4 of us initiated the group, but the group is open to anyone who wants to join.

The group members proposed to me as the initial chairperson (rotating role). Following the fantastic scheme proposed by the [DX working group](https://github.com/asyncapi/community/pull/1088/commits/19434d44b681af690f1558c2bbad9db837b8ac73), the chairperson will be accountable and responsible for the following:

- Manage the overall vision and direction of the working group
- Oversee the development and maintenance of the roadmap
- Mediate conflicts and ensure a positive and safe working atmosphere
- Monitor and maintain Working group goals
- Communicate Working group achievements

**Responsibilities of the members**

- Active participation in the Community Growth working group
- Vote for key decisions (e.g., the selection of new members, chairperson rotation ...)
- Influence the working group roadmap
- Assist in the onboarding process for new members
- Provide insights and expertise to enhance the group's effectiveness

**Requirement to join as a member**

- Active AsyncAPI contribution (maintainer / aspiring maintainer)