### PR TITLE
docs: added all required GSoC documentations

### DIFF
--- a/mentorship/summerofcode/README.md
+++ b/mentorship/summerofcode/README.md
@@ -1,0 +1,43 @@
+# Google Summer of Code - Getting Started
+
+###### Introduction
+
+Google Summer of Code (GSoC) is an annual program sponsored by Google that offers stipends to contributors for working on open-source projects during the summer. Contributors gain real-world software development experience by working with mentors from participating organizations. The goal is to encourage developers to contribute to open-source projects and improve their coding skills. If you want to develop open-source software, this program is for you! 
+
+AsyncAPI is looking for contributors who are eager to learn, have good coding abilities, and, most importantly, have a strong passion for APIs and open-source development. 
+
+
+### Requirement
+
+Successful GSoC contributors will receive [compensation](https://developers.google.com/open-source/gsoc/help/student-stipends) for their contributions.
+
+To be eligible as a contributor, you must be at least 18 years old at the time of registration and be new to open-source projects. Group applications are not permitted. 
+
+Please verify your eligibility by visiting the [Google Summer of Code (GSoC) website.](https://summerofcode.withgoogle.com/get-started)
+
+TL;DR: GSoC exclusively focuses on coding projects. While initiatives like documentation or design are valuable, they are not permitted within the scope of GSoC. You can check out the AsyncAPI Mentorship Program or GSoD for other noncoding-related projects.
+
+### First Steps
+
+- **The ideal starting point is Google's [Student Guide](https://google.github.io/gsocguides/student)**!
+  Carefully read through it to familiarize yourself with the initiative. The guide provides a comprehensive program overview and offers valuable advice on starting communication, proposal writing, and beginning your work. Additionally, refer to Google's [FAQ](https://developers.google.com/open-source/gsoc/faq) for more information.
+
+- **Get familiar with the AsyncAPI project.**
+  Please familiarize yourself with the AsyncAPI initiative and its mission and get involved in the [community.](https://asyncapi.com/slack-invite) Explore the [AsyncAPI projects](https://github.com/asyncapi), get an idea of the project of your interest, explore the source code and how the project is organized.
+
+- **Write your project proposal.**
+  Visit the [ideas page](https://github.com/asyncapi/community/blob/master/mentorship/summerofcode/2024/asyncapi-gsoc-ideas-page.md) to choose a topic that catches your interest. You can also draw inspiration from projects from [previous years](https://github.com/asyncapi/community/tree/master/mentorship/summerofcode).
+  
+  We also recommend reading Google's [guide for writing a proposal](https://google.github.io/gsocguides/student/writing-a-proposal).
+
+  For feedback, submit your work early! Keep in mind that feedback may only be available during the final week after the deadline due to the influx of applications.
+
+### Getting Started with AsyncAPI
+- New to AsyncAPI? Visit the [AsyncAPI website](asyncapi.com) to learn more about the initiative in general.
+- Visit the [Community section](https://www.asyncapi.com/community) of the website to learn about the community behind AsyncAPI.
+- Explore all the active projects in the organization by visiting our [GitHub org][https://github.com/asyncapi].
+-  Consider tackling one of the good first issues, resolving a bug, or enhancing existing features by visiting our [Issues Dashboard](https://www.asyncapi.com/community/dashboard). Include links to your past contributions to AsyncAPI in your proposal. Stay calm! If you're new to navigating a large codebase, we are here to help you :).
+
+### Thanks! 
+
+  We appreciate your interest in choosing AsyncAPI for your Google Summer of Code project!

--- a/mentorship/summerofcode/README.md
+++ b/mentorship/summerofcode/README.md
@@ -20,7 +20,7 @@ TL;DR: GSoC exclusively focuses on coding projects. While initiatives like docum
 ### First Steps
 
 - **The ideal starting point is Google's [Student Guide](https://google.github.io/gsocguides/student)**!
-  Carefully read through it to familiarize yourself with the initiative. The guide provides a comprehensive program overview and offers valuable advice on starting communication, proposal writing, and beginning your work. Additionally, refer to Google's [FAQ](https://developers.google.com/open-source/gsoc/faq) for more information.
+  Carefully read through the guide to familiarize yourself with the initiative. The guide provides a comprehensive program overview and offers valuable advice on starting communication, proposal writing, and beginning your work. Additionally, refer to Google's [FAQ](https://developers.google.com/open-source/gsoc/faq) for more information.
 
 - **Get familiar with the AsyncAPI project.**
   Please familiarize yourself with the AsyncAPI initiative and its mission and get involved in the [community.](https://asyncapi.com/slack-invite) Explore the [AsyncAPI projects](https://github.com/asyncapi), get an idea of the project of your interest, explore the source code and how the project is organized.

--- a/mentorship/summerofcode/README.md
+++ b/mentorship/summerofcode/README.md
@@ -19,24 +19,24 @@ TL;DR: GSoC exclusively focuses on coding projects. While initiatives like docum
 
 ### First Steps
 
-- **The ideal starting point is Google's [Student Guide](https://google.github.io/gsocguides/student)**!
-  Carefully read through the guide to familiarize yourself with the initiative. The guide provides a comprehensive program overview and offers valuable advice on starting communication, proposal writing, and beginning your work. Additionally, refer to Google's [FAQ](https://developers.google.com/open-source/gsoc/faq) for more information.
+- **The ideal starting point is [Google's Student Guide](https://google.github.io/gsocguides/student)**!
+  Carefully read through the guide to familiarize yourself with the initiative. The guide provides a comprehensive program overview and offers valuable advice on starting communication, proposal writing, and beginning your work. Additionally, [refer to Google's FAQ](https://developers.google.com/open-source/gsoc/faq) for more information.
 
 - **Get familiar with the AsyncAPI project.**
-  Please familiarize yourself with the AsyncAPI initiative and its mission and get involved in the [community.](https://asyncapi.com/slack-invite) Explore the [AsyncAPI projects](https://github.com/asyncapi), get an idea of the project of your interest, explore the source code and how the project is organized.
+  Please be sure to familiarize yourself with the AsyncAPI initiative and its mission and [get involved in the community](https://asyncapi.com/slack-invite). Explore the [AsyncAPI projects](https://github.com/asyncapi), get an idea of the project of your interest, and explore the source code and organization of the project.
 
 - **Write your project proposal.**
   Visit the [ideas page](https://github.com/asyncapi/community/blob/master/mentorship/summerofcode/2024/asyncapi-gsoc-ideas-page.md) to choose a topic that catches your interest. You can also draw inspiration from projects from [previous years](https://github.com/asyncapi/community/tree/master/mentorship/summerofcode).
   
-  We also recommend reading Google's [guide for writing a proposal](https://google.github.io/gsocguides/student/writing-a-proposal).
+  We recommend reading [Google's guide for writing a proposal](https://google.github.io/gsocguides/student/writing-a-proposal).
 
-  For feedback, submit your work early! Keep in mind that feedback may only be available during the final week after the deadline due to the influx of applications.
+  For feedback, submit your work early! However, due to the influx of applications, feedback may only be available during the final week after the deadline.
 
 ### Getting Started with AsyncAPI
-- New to AsyncAPI? Visit the [AsyncAPI website](asyncapi.com) to learn more about the initiative in general.
+- New to AsyncAPI? Visit the [AsyncAPI website](asyncapi.com) to learn more about the initiative.
 - Visit the [Community section](https://www.asyncapi.com/community) of the website to learn about the community behind AsyncAPI.
-- Explore all the active projects in the organization by visiting our [GitHub org][https://github.com/asyncapi].
--  Consider tackling one of the good first issues, resolving a bug, or enhancing existing features by visiting our [Issues Dashboard](https://www.asyncapi.com/community/dashboard). Include links to your past contributions to AsyncAPI in your proposal. Stay calm! If you're new to navigating a large codebase, we are here to help you :).
+- Explore all the active projects in the organization by visiting our [GitHub org](https://github.com/asyncapi).
+- Consider tackling one of the good first issues, resolving a bug, or enhancing existing features by visiting our [Issues Dashboard](https://www.asyncapi.com/community/dashboard). Include links to your past contributions to AsyncAPI in your proposal. Stay calm! If you're new to navigating a large codebase, we are here to help you 😊.
 
 ### Thanks! 
 

--- a/mentorship/summerofcode/application-template.md
+++ b/mentorship/summerofcode/application-template.md
@@ -1,6 +1,6 @@
 # GSoC Application Template
 
-This is the AsyncAPI Project's Google Summer of Code Application Template. We made it to assist contributors in crafting impressive proposals that will impress us. You can submit a draft proposal early to get feedback and iterate early. Be sure to read Google's [guide to writing a proposal](https://google.github.io/gsocguides/student/writing-a-proposal)
+This is the AsyncAPI Project's Google Summer of Code Application Template. We made it to assist contributors in crafting impressive proposals that will impress us. You can submit a draft proposal early to get feedback and iterate early. Be sure to read [Google's guide to writing a proposal](https://google.github.io/gsocguides/student/writing-a-proposal)
 
 Here's what we want to hear from you:
 
@@ -16,7 +16,7 @@ Please provide your most basic contact information, such as:
 
 This section is for you to provide all your understanding of the project, such as:
 - What is the aim of your project, and what problem does it aim to address?
-- Providing a detailed description of the proposed project. Here's where to add technical explanations, architectural diagrams or design mockups.
+- Providing a detailed description of the proposed project. Here's where to add technical explanations, architectural diagrams, or design mockups.
 - What will the outcome of your project be at the end of the program?
 - How do you plan to finish the project on schedule? For instance, what are the important milestones, and what is your approximate timeline for reaching them?
 - What qualities should a suitable mentor for your project possess?
@@ -24,11 +24,11 @@ This section is for you to provide all your understanding of the project, such a
 
 ### Your Understanding of AsyncAPI
 
-AsyncAPI, as an initiative, has a lot of projects and design patterns. In this section, we assess your familiarity with AsyncAPI. We encourage seasoned AsyncAPI users and newcomers to explore and understand AsyncAPI during the application phase.
+AsyncAPI is an initiative with many projects and design patterns. In this section, we assess your familiarity with AsyncAPI. We encourage seasoned users and newcomers to explore and understand AsyncAPI during the application phase.
 
 - Please share your background as an AsyncAPI user or contributor, or if you're new to AsyncAPI, outline your intentions for learning AsyncAPI. 
 - If you've submitted bug fixes or patches to any of our projects before, please provide links to the repositories for one or more examples of your work with AsyncAPI.
-- Please explain your knowledge of the AsyncAPI development infrastructure and Git(a plus if it's for your chosen project). If you're unfamiliar with them, what are your plans for learning? We encourage you to use the application period to familiarize yourself with these tools.
+- Please explain your knowledge of the AsyncAPI development infrastructure and Git(a plus if it's for your chosen project). If you're unfamiliar with them, what do you plan to learn? We'd like to encourage you to use the application period to familiarize yourself with these tools.
 -   Include or share links to a sample of code unrelated to AsyncAPI demonstrating your development abilities(Optional).
 
 ### Your Involvement with the AsyncAPI community
@@ -37,7 +37,7 @@ We welcome applications from folks new to AsyncAPI. If you have previous experie
 
 - How long have you been engaged with the AsyncAPI community? For instance, have you attended community meetings, contributed to the website, or participated in AsyncAPI events in any capacity?
 - Have you developed and released any project or offered support or services (voluntary or commercial) to AsyncAPI users independently from the official AsyncAPI project?
-- If you have yet to engage with the AsyncAPI community, what are your plans for getting involved?
+- If you have not engaged with the AsyncAPI community, what are your plans for getting involved?
 - What are your intentions for contributing to AsyncAPI besides your project work? Do you anticipate continuing your involvement with AsyncAPI after finishing your project? If yes, how do you plan to do so?
 
 ### Bio

--- a/mentorship/summerofcode/application-template.md
+++ b/mentorship/summerofcode/application-template.md
@@ -1,0 +1,45 @@
+# GSoC Application Template
+
+This is the AsyncAPI Project's Google Summer of Code Application Template. We made it to assist contributors in crafting impressive proposals that will impress us. You can submit a draft proposal early to get feedback and iterate early. Be sure to read Google's [guide to writing a proposal](https://google.github.io/gsocguides/student/writing-a-proposal)
+
+Here's what we want to hear from you:
+
+### Contact information
+
+Please provide your most basic contact information, such as:
+- Full name
+- Email address
+- GitHub handle
+- Contact Number(include your country code)
+
+### Project Information
+
+This section is for you to provide all your understanding of the project, such as:
+- What is the aim of your project, and what problem does it aim to address?
+- Providing a detailed description of the proposed project. Here's where to add technical explanations, architectural diagrams or design mockups.
+- What will the outcome of your project be at the end of the program?
+- How do you plan to finish the project on schedule? For instance, what are the important milestones, and what is your approximate timeline for reaching them?
+- What qualities should a suitable mentor for your project possess?
+- What are your plans for the project after completion? 
+
+### Your Understanding of AsyncAPI
+
+AsyncAPI, as an initiative, has a lot of projects and design patterns. In this section, we assess your familiarity with AsyncAPI. We encourage seasoned AsyncAPI users and newcomers to explore and understand AsyncAPI during the application phase.
+
+- Please share your background as an AsyncAPI user or contributor, or if you're new to AsyncAPI, outline your intentions for learning AsyncAPI. 
+- If you've submitted bug fixes or patches to any of our projects before, please provide links to the repositories for one or more examples of your work with AsyncAPI.
+- Please explain your knowledge of the AsyncAPI development infrastructure and Git(a plus if it's for your chosen project). If you're unfamiliar with them, what are your plans for learning? We encourage you to use the application period to familiarize yourself with these tools.
+-   Include or share links to a sample of code unrelated to AsyncAPI demonstrating your development abilities(Optional).
+
+### Your Involvement with the AsyncAPI community
+
+We welcome applications from folks new to AsyncAPI. If you have previous experience with the AsyncAPI community, please share it. We encourage newcomers to use this application period to get involved with the AsyncAPI community.
+
+- How long have you been engaged with the AsyncAPI community? For instance, have you attended community meetings, contributed to the website, or participated in AsyncAPI events in any capacity?
+- Have you developed and released any project or offered support or services (voluntary or commercial) to AsyncAPI users independently from the official AsyncAPI project?
+- If you have yet to engage with the AsyncAPI community, what are your plans for getting involved?
+- What are your intentions for contributing to AsyncAPI besides your project work? Do you anticipate continuing your involvement with AsyncAPI after finishing your project? If yes, how do you plan to do so?
+
+### Bio
+
+Share a bit about yourself. What are you studying and where? What activities do you enjoy? Why are you the right person for this project?

--- a/mentorship/summerofcode/mentors-guideline.md
+++ b/mentorship/summerofcode/mentors-guideline.md
@@ -1,0 +1,26 @@
+# GSoC Mentor's Guideline
+
+##### Introduction
+
+Hey there! Welcome to the Google Summer of Code (GSoC) mentors' guideline. As a mentor, you play a crucial role in guiding and supporting contributors throughout their GSoC journey. This guideline outlines key responsibilities, best practices, and tips to ensure a successful mentoring experience.
+
+### Key Responsibilities
+
+To participate in the Program, mentors must be contributors or maintainers to any project run by AsyncAPI and not be a participants in the Program. Here are some key responsibilities we expect from our mentors.
+
+- You'll need to provide guidance, support, and direction to your GSoC contributors throughout the project timeline. It's important to encourage collaboration among GSoC contributors and mentors as well. You'll also need to set reasonable expectations and clearly define project goals, milestones, and expectations at the beginning of the Program.
+
+- Regular communication is essential too. You'll need to maintain effective communication with your contributors through preferred channels such as email, Slack, or video calls. Be readily available and responsive to GSoC contributors' questions, concerns, and requests for assistance. Don't forget to review code submissions, provide constructive feedback, and help contributors improve their coding skills.
+
+- Please also encourage contributors to engage with the AsyncAPI community, attend meetings, seek help from fellow community members and encourage them to share their achievements and milestones with the rest of the community. Make sure that project documentation is up-to-date and accessible for reference to interested contributors.
+### Contributors Selection Process
+
+When it comes to selecting contributors for GSoC there are a few things you should consider as a mentor:
+
+- You'll need to ensure that their proposal aligns well with the project goals, objectives, and requirements. Assess their technical skills and proficiency in relevant programming languages, tools, and technologies required for the project. And don't hesitate to interview candidates if you need more convincing by their proposals.
+
+- You'll need to assess communication skills, responsiveness, and ability to collaborate effectively with mentors and the community are also important points to consider. You should also evaluate the interested GSoC contributor's commitment level, availability, and willingness to dedicate time and effort to the project throughout the Program. Take a look at any past contributions, code submissions, or involvement in open-source projects to scale the GSoC contributor's experience and dedication to the community.
+
+### Conclusion
+
+Thank you for your dedication and commitment as a GSoC mentor. Your guidance and support are invaluable in helping contributors succeed and contribute to AsyncAPI. Best of luck for a productive and rewarding GSoC mentoring experience!

--- a/mentorship/summerofcode/mentors-guideline.md
+++ b/mentorship/summerofcode/mentors-guideline.md
@@ -2,24 +2,24 @@
 
 ##### Introduction
 
-Hey there! Welcome to the Google Summer of Code (GSoC) mentors' guideline. As a mentor, you play a crucial role in guiding and supporting contributors throughout their GSoC journey. This guideline outlines key responsibilities, best practices, and tips to ensure a successful mentoring experience.
+Hey there! Welcome to the Google Summer of Code (GSoC) mentors' guideline. As a mentor, you are crucial in guiding and supporting contributors throughout their GSoC journey. This guideline outlines key responsibilities, best practices, and tips to ensure a successful mentoring experience.
 
 ### Key Responsibilities
 
-To participate in the Program, mentors must be contributors or maintainers to any project run by AsyncAPI and not be a participants in the Program. Here are some key responsibilities we expect from our mentors.
+To participate in the Program, mentors must be contributors or maintainers to any project run by AsyncAPI and not be a participant in the Program. Here are some key responsibilities we expect from our mentors.
 
 - You'll need to provide guidance, support, and direction to your GSoC contributors throughout the project timeline. It's important to encourage collaboration among GSoC contributors and mentors as well. You'll also need to set reasonable expectations and clearly define project goals, milestones, and expectations at the beginning of the Program.
 
-- Regular communication is essential too. You'll need to maintain effective communication with your contributors through preferred channels such as email, Slack, or video calls. Be readily available and responsive to GSoC contributors' questions, concerns, and requests for assistance. Don't forget to review code submissions, provide constructive feedback, and help contributors improve their coding skills.
+- Regular communication is also essential. You'll need to communicate effectively with your contributors through preferred channels such as email, Slack, or video calls. Be readily available and responsive to GSoC contributors' questions, concerns, and requests for assistance. Remember to review code submissions, provide constructive feedback, and help contributors improve their coding skills.
 
-- Please also encourage contributors to engage with the AsyncAPI community, attend meetings, seek help from fellow community members and encourage them to share their achievements and milestones with the rest of the community. Make sure that project documentation is up-to-date and accessible for reference to interested contributors.
+- Please also encourage contributors to engage with the AsyncAPI community, attend meetings, seek help from fellow community members, and encourage them to share their achievements and milestones with the rest of the community. Make sure that project documentation is up-to-date and accessible for reference to interested contributors.
 ### Contributors Selection Process
 
-When it comes to selecting contributors for GSoC there are a few things you should consider as a mentor:
+When it comes to selecting contributors for GSoC, there are a few things you should consider as a mentor:
 
-- You'll need to ensure that their proposal aligns well with the project goals, objectives, and requirements. Assess their technical skills and proficiency in relevant programming languages, tools, and technologies required for the project. And don't hesitate to interview candidates if you need more convincing by their proposals.
+- You must ensure their proposal aligns well with the project goals, objectives, and requirements. Assess their technical skills and proficiency in relevant programming languages, tools, and technologies required for the project. And don't hesitate to interview candidates if you need to be more convinced by their proposals.
 
-- You'll need to assess communication skills, responsiveness, and ability to collaborate effectively with mentors and the community are also important points to consider. You should also evaluate the interested GSoC contributor's commitment level, availability, and willingness to dedicate time and effort to the project throughout the Program. Take a look at any past contributions, code submissions, or involvement in open-source projects to scale the GSoC contributor's experience and dedication to the community.
+- You'll need to assess communication skills, responsiveness, and the ability to collaborate effectively with mentors and the community. These are also important points to consider. You should also evaluate the interested GSoC contributor's commitment level, availability, and willingness to dedicate time and effort to the project throughout the Program. Look at past contributions, code submissions, or involvement in open-source projects to scale the GSoC contributor's experience and dedication to the community.
 
 ### Conclusion
 


### PR DESCRIPTION
This PR includes some of the most important GSoC documentation, such as the following:

- Getting Started Guide
- Application Template
- Mentor's Guideline

cc @alequetzalli @thulieblack 