### PR TITLE
docs: update list of repos owned by smoya

### DIFF
--- a/MAINTAINERS.yaml
+++ b/MAINTAINERS.yaml
@@ -314,16 +314,18 @@
   company: Postman
   isTscMember: true
   repos:
-    - bindings
-    - converter-go
-    - event-gateway
-    - go-watermill-template
-    - infra
-    - parser-api
-    - parser-go
-    - server-api
     - spec
     - spec-json-schemas
+    - bindings
+    - parser-api
+    - parser-js
+    - avro-schema-parser
+    - openapi-schema-parser
+    - raml-dt-schema-parser
+    - server-api
+    - parser-go
+    - converter-go
+    - go-watermill-template
     - template-for-go-projects
 - name: Souvik De
   github: souvikns


### PR DESCRIPTION
**Description**

This PR updates the list of repositories I own in the `MAINTAINERS.yaml` file. 
Additionally, I'm removing `event-gateway` and `infra` from the list since both are gonna be moved to the archive pretty soon. See https://github.com/orgs/asyncapi/discussions/1045 and https://github.com/asyncapi/infra/issues/62.