### PR TITLE
chore: bump action version to v2.4.0

### DIFF
--- a/.github/workflows/youtube-to-spotify-for-podcasters.yml
+++ b/.github/workflows/youtube-to-spotify-for-podcasters.yml
@@ -26,7 +26,7 @@ jobs:
           # Verify the content was written successfully
           cat episode.json
       - name: Upload Episode from YouTube To Anchor.Fm
-        uses: Schrodinger-Hat/youtube-to-anchorfm@c722f3edeee94f3173dad36c5a959247973c5253 #commit related to https://github.com/Schrodinger-Hat/youtube-to-anchorfm/commit/c722f3edeee94f3173dad36c5a959247973c5253 || The latest commit which is of Nov 14, 2023
+        uses: Schrodinger-Hat/youtube-to-anchorfm@b02b82f809d24db88472a78c51ffa627f46a6dc3 #commit related to https://github.com/Schrodinger-Hat/youtube-to-anchorfm/commit/b02b82f809d24db88472a78c51ffa627f46a6dc3 || The latest commit which refers to v2.4.0 of the action
         env:
           ANCHOR_EMAIL: ${{ secrets.ANCHOR_EMAIL }}
           ANCHOR_PASSWORD: ${{ secrets.ANCHOR_PASSWORD }}


### PR DESCRIPTION
**Description**

This PR updated the `youtube-to-anchorfm` action version to the latest version, i.e., v2.4.0.

- [Commit associated with the v2.4.0](https://github.com/Schrodinger-Hat/youtube-to-anchorfm/commit/b02b82f809d24db88472a78c51ffa627f46a6dc3)
- [More information about this release](https://github.com/Schrodinger-Hat/youtube-to-anchorfm/releases/tag/v2.4.0)

PTAL @thulieblack and give the workflow a run after merging this PR. Do let me know how it went... :+1: 

**Related issue(s)**
Fixes #1127 