### PR TITLE
chore: move TSC members arjungarg07 and  boyney123 to emeritus

### DIFF
--- a/Emeritus.yaml
+++ b/Emeritus.yaml
@@ -3,3 +3,5 @@ emeritus:
   - jotamusik 
   - LouisXhaferi
   - aeworxet
+  - arjungarg07
+  - boyney123

--- a/MAINTAINERS.yaml
+++ b/MAINTAINERS.yaml
@@ -42,15 +42,6 @@
   isTscMember: true
   repos:
     - go-watermill-template
-- name: Arjun Garg
-  github: arjungarg07
-  linkedin: arjungarg17
-  slack: U01QX79S734
-  twitter: ArjunGarg07
-  availableForHire: true
-  isTscMember: true
-  repos:
-    - cupid
 - name: Ashish Padhy
   github: Shurtu-gal
   linkedin: ashish-padhy3023
@@ -396,16 +387,6 @@
   isTscMember: true
   repos:
     - java-template
-- name: David Boyne
-  github: boyney123
-  twitter: boyney123
-  slack: U020GN9C6FM
-  availableForHire: false
-  company: AWS
-  isTscMember: true
-  repos:
-    - studio
-    - cli
 - name: Semen Tenishchev
   github: tenischev
   linkedin: semen-tenishchev


### PR DESCRIPTION
We just archived cupid project and I also know that @arjungarg07 cannot be longer with us - thanks for all the work you did to AsyncAPI 👏🏼 

David is no longer maintainer of cli and studio, thus also moving @boyney123 to emeritus as he no longer maintains any repo in AsyncAPI. Thanks David for all the work and best of luck with https://github.com/boyney123/eventcatalog, please talk about it