### PR TITLE
chore: add Quetzalli as alternative host

### DIFF
--- a/.github/workflows/create-event-ad-hoc.yml
+++ b/.github/workflows/create-event-ad-hoc.yml
@@ -30,7 +30,7 @@ jobs:
       meeting_desc: ${{ github.event.inputs.desc }}
       meeting_banner: ${{ github.event.inputs.meeting_banner }}
       host: lpgornicki@gmail.com
-      alternative_host: "fmvilas@gmail.com,jonas-lt@live.dk,devlopergene@gmail.com,sibanda.thulie@gmail.com"
+      alternative_host: "fmvilas@gmail.com,jonas-lt@live.dk,devlopergene@gmail.com,sibanda.thulie@gmail.com,alejandra.olvera.novack@gmail.com"
       issue_template_path: .github/workflows/create-event-helpers/issues_templates/ad-hoc.md
       create_zoom: true
     secrets:


### PR DESCRIPTION
Adding myself as alternative host, per @smoya's request in Slack for our Maintainer Working Group meetings: https://asyncapi.slack.com/archives/C06GGK7EMSA/p1715080521745239?thread_ts=1714933530.843279&cid=C06GGK7EMSA.  