### PR TITLE
chore: add @asyncapi/code_of_conduct as code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,3 +9,6 @@
 
 # All ambassadors related files
 AMBASSADOR* @thulieblack
+
+# Code Of Conduct
+/code_of_conduct/ @asyncapi/code_of_conduct


### PR DESCRIPTION
**Description**

This PR sets the @asyncapi/code_of_conduct team as code owner for the `CODE_OF_CONDUCT.md` and all files under `code_of_conduct` dir.