### PR TITLE
chore: revert "feat: update CoC"

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,87 +1,46 @@
-# AsyncAPI Code of Conduct
-
-## Introduction
-Welcome to our community! We are a diverse group of individuals united by our passion for open source and commitment to inclusivity.
-
-Our community promotes and supports inclusivity, welcoming individuals from all backgrounds and experiences. We believe that diversity is our strength, and we actively seek participation from those who enhance it.
-
-Our Code of Conduct governs how we behave publicly or privately when representing the project. It ensures that diverse groups collaborate for mutual advantage and enjoyment and challenges prejudice that could jeopardize anyone's participation in the project.
-
-We expect everyone in our community to treat each other with kindness, empathy, and respect. We believe fostering a welcoming and respectful environment can create a positive and successful community.
+# Contributor Covenant Code of Conduct
 
 ## Our Pledge
 
-As members, contributors, and admins of our community, we pledge to ensure that every individual is treated with respect and dignity. We pledge to create a safe, inclusive, and welcoming environment that is free from any form of harassment or discrimination regardless of differences in age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
-
-We pledge to encourage a diverse, healthy community that celebrates individuality and promotes equality. We will act and interact in ways that promote openness, empathy, understanding, and acceptance of everyone's unique perspectives and experiences.
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
-### Examples of behavior that contributes to a positive environment for our community include:
+Examples of behavior that contributes to creating a positive environment include:
 
-- Using welcoming and inclusive language.
-- Being respectful of differing viewpoints and experiences.
-- Gracefully accepting constructive criticism.
-- Focusing on what is best for the community.
-- Showing empathy towards other community members.
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
-### Examples of unacceptable behavior include:
+Examples of unacceptable behavior by participants include:
 
-- The use of sexualized language or imagery and unwelcome sexual attention or advances.
-- Trolling, insulting/derogatory comments, and personal or political attacks.
-- Public or private harassment.
-- Publishing others' private information, such as a physical or electronic address, without explicit permission.
-- Publishing content or comments that promote illegal activities.
-- Violence, threats of violence, or violent language.
-- Other conduct that could reasonably be considered inappropriate in a professional setting.
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
 ## Scope
 
 This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
 
-## Enforce Responsibilities
-
-The Code of Conduct Committee (CoC Committee) responds to, investigates, and resolves AsyncAPI Incidents. The Committee is responsible for clarifying the standards of acceptable behavior and taking appropriate and fair corrective action in response to unacceptable behavior.
-
-The Committee has the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that do not align with this Code of Conduct. The Committee may also temporarily or permanently ban any contributor for inappropriate, threatening, offensive, or harmful behaviors to the community.
-
-For more details, please see the [CoC Committee and Incident Resolution Procedure](https://github.com/asyncapi/community/pull/1013/files).
-
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at condcut@asyncapi.io. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at fmvilas@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
-All community leaders are obligated to respect the privacy and security of the reporter of any incident.
-
-## Enforcement Guidelines
-Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
-
-### 1. Correction
-Community Impact: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
-
-Consequence: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
-
-### 2. Warning
-Community Impact: A violation through a single incident or series of actions.
-
-Consequence: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
-
-### 3. Temporary Ban
-Community Impact: A serious violation of community standards, including sustained inappropriate behavior.
-
-Consequence: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
-
-### 4. Permanent Ban
-Community Impact: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
-
-Consequence: A permanent ban from any sort of public interaction within the community.
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [http://contributor-covenant.org/version/2/1][version].
-
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
 
 [homepage]: http://contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/inclusion
+[version]: http://contributor-covenant.org/version/1/4/


### PR DESCRIPTION
Reverts asyncapi/community#1132

Reason is that such a file is centralized in .github repo, meaning all changes should be done there.

New PR: https://github.com/asyncapi/.github/pull/303