### PR TITLE
ci: update the vote command to match instead of contains

### DIFF
--- a/.github/workflows/vote-verifcation.yml
+++ b/.github/workflows/vote-verifcation.yml
@@ -17,7 +17,7 @@ jobs:
           authorName: "${{github.event.comment.user.login}}"
 
       - name: Checking the person authenticity.
-        if:  contains(github.event.comment.body, '/vote') || contains(github.event.comment.body, '/cancel-vote')
+        if: (github.event.comment.body == '/vote') || (github.event.comment.body == '/cancel-vote')
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_TOKEN_BOT_EVE }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This update addresses issue #1273 where the GitHub Actions workflow was erroneously triggered by any comment containing the substrings "vote" or "cancel vote." The solution ensures that the workflow only runs when the comment exactly matches /vote or /cancel-vote. By using the == operator for exact string comparison, we prevent unintended activations of the workflow, ensuring precise and correct handling of voting commands.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes #1273