### PR TITLE
chore: removing Gerald Loeffler from TSC_MEMBERS.json

### DIFF
--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -114,17 +114,6 @@
 		]
 	},
 	{
-		"name": "Gerald Loeffler",
-		"github": "GeraldLoeffler",
-		"linkedin": "geraldloeffler",
-		"slack": "U01P5QDLP0X",
-		"availableForHire": false,
-		"company": "Salesforce",
-		"repos": [
-			"bindings"
-		]
-	},
-	{
 		"name": "Jonas Lagoni",
 		"github": "jonaslagoni",
 		"linkedin": "jonaslagoni",


### PR DESCRIPTION
I'm currently not able to help with TSC processes. I'm still a maintenance worker, but please remove me from TSC for now. IF things change in future, I'll open a PR to add me back again.