### PR TITLE
ci: remove fmvilas from alternative hosts list

### DIFF
--- a/.github/workflows/create-event-ad-hoc.yml
+++ b/.github/workflows/create-event-ad-hoc.yml
@@ -30,7 +30,7 @@ jobs:
       meeting_desc: ${{ github.event.inputs.desc }}
       meeting_banner: ${{ github.event.inputs.meeting_banner }}
       host: lpgornicki@gmail.com
-      alternative_host: "fmvilas@gmail.com,jonas-lt@live.dk,devlopergene@gmail.com,sibanda.thulie@gmail.com,alejandra.olvera.novack@gmail.com,samir.amzani@gmail.com"
+      alternative_host: "jonas-lt@live.dk,devlopergene@gmail.com,sibanda.thulie@gmail.com,alejandra.olvera.novack@gmail.com,samir.amzani@gmail.com"
       issue_template_path: .github/workflows/create-event-helpers/issues_templates/ad-hoc.md
       create_zoom: true
     secrets:

--- a/.github/workflows/create-event-community-meeting.yml
+++ b/.github/workflows/create-event-community-meeting.yml
@@ -23,7 +23,7 @@ jobs:
       meeting_name: Community Meeting
       meeting_desc: This is a community meeting to regularly talk in open about important topics around AsyncAPI Initiative.
       host: lpgornicki@gmail.com
-      alternative_host: 'fmvilas@gmail.com,devlopergene@gmail.com,sibanda.thulie@gmail.com'
+      alternative_host: 'devlopergene@gmail.com,sibanda.thulie@gmail.com'
       issue_template_path: .github/workflows/create-event-helpers/issues_templates/community.md
       create_zoom: true
     secrets:

--- a/.github/workflows/create-event-lets-talk-about.yml
+++ b/.github/workflows/create-event-lets-talk-about.yml
@@ -27,7 +27,7 @@ jobs:
       meeting_banner: ${{ github.event.inputs.meeting_banner }}
       meeting_desc: The purpose of this meeting is to focus on contributors, focus on people that want to contribute to AsyncAPI Initiative but do not know how to do it.
       host: lpgornicki@gmail.com
-      alternative_host: 'fmvilas@gmail.com,devlopergene@gmail.com,sibanda.thulie@gmail.com'
+      alternative_host: 'devlopergene@gmail.com,sibanda.thulie@gmail.com'
       issue_template_path: .github/workflows/create-event-helpers/issues_templates/lets-talk-about-contrib.md
       create_zoom: false
     secrets:

--- a/.github/workflows/create-event-spec-3-0.yml
+++ b/.github/workflows/create-event-spec-3-0.yml
@@ -24,7 +24,7 @@ jobs:
       meeting_name: Spec 3.0 Meeting
       meeting_desc: This is the meeting for community member involved in works related to 3.0 release of AsyncAPI Specification.
       host: jonas-lt@live.dk
-      alternative_host: fmvilas@gmail.com
+      alternative_host: lpgornicki@gmail.com
       issue_template_path: .github/workflows/create-event-helpers/issues_templates/spec-3-0.md
       create_zoom: true
     secrets:

--- a/.github/workflows/create-event-spec-3-docs.yml
+++ b/.github/workflows/create-event-spec-3-docs.yml
@@ -23,7 +23,7 @@ jobs:
       meeting_name: Spec 3.0 Docs Meeting
       meeting_desc: This is a open meeting to plan and write Spec 3.0 Docs.
       host: alejandra.olvera.novack@gmail.com
-      alternative_host: 'fmvilas@gmail.com,devlopergene@gmail.com,sibanda.thulie@gmail.com,jonas-lt@live.dk,lpgornicki@gmail.com'
+      alternative_host: 'devlopergene@gmail.com,sibanda.thulie@gmail.com,jonas-lt@live.dk,lpgornicki@gmail.com'
       issue_template_path: .github/workflows/create-event-helpers/issues_templates/spec-3-docs.md
       create_zoom: true
     secrets:

--- a/.github/workflows/create-event-thinking-out-loud.yml
+++ b/.github/workflows/create-event-thinking-out-loud.yml
@@ -29,7 +29,7 @@ jobs:
       meeting_name: Thinking Out Loud
       meeting_desc: ${{ github.event.inputs.desc }}
       guest: ${{ github.event.inputs.guest }}
-      host: fmvilas@gmail.com
+      host: lpgornicki@gmail.com
       issue_template_path: .github/workflows/create-event-helpers/issues_templates/thinking-out-loud.md
       create_zoom: true
     secrets:


### PR DESCRIPTION
**Description**

Fran shared he is not actually organising meetings atm so better to remove him from alternative hosts.

**Related issue(s)**
Fixes https://github.com/asyncapi/community/actions/runs/9566927143/job/26373495416#step:6:23