### PR TITLE
chore: cleanup TSC list

### DIFF
--- a/Emeritus.yaml
+++ b/Emeritus.yaml
@@ -6,3 +6,12 @@ emeritus:
   - arjungarg07
   - boyney123
   - Barbanio
+  - mcturco
+  - damaru-inc
+  - geraldloeffler
+  - ron-debajyoti
+  - char0n
+  - kieranm1999
+  - jefflufc
+  - lewis-relph
+  - emilianozublena

--- a/MAINTAINERS.yaml
+++ b/MAINTAINERS.yaml
@@ -87,14 +87,13 @@
   linkedin: emilianozublena
   slack: U01LYC8PW0M
   availableForHire: false
-  isTscMember: true
+  isTscMember: false
   repos:
     - asyncapi-php-template
 - name: Fran Méndez
   github: fmvilas
   slack: U34F2JRRS
   availableForHire: false
-  company: Postman
   linkedin: fmvilas
   isTscMember: true
   repos:
@@ -103,22 +102,17 @@
     - openapi-schema-parser
     - asyncapi-react
     - glee
-    - generator
-    - nodejs-template
     - nodejs-ws-template
     - parser-js
-    - playground
     - spec
     - spec-json-schemas
-    - website
     - bindings
 - name: Gerald Loeffler
   github: geraldloeffler
   linkedin: geraldloeffler
   slack: U01P5QDLP0X
   availableForHire: false
-  company: Salesforce
-  isTscMember: true
+  isTscMember: false
   repos:
     - bindings
 - name: Jonas Lagoni
@@ -156,6 +150,7 @@
   linkedin: laurentbroudoux
   slack: U018NLDV5E1
   availableForHire: false
+  company: Postman
   isTscMember: true
   repos:
     - bindings
@@ -165,7 +160,7 @@
   slack: U01BM49KL3Z
   twitter: ldussart
   availableForHire: false
-  company: Ineat
+  company: zatsit
   isTscMember: true
   repos:
     - avro-schema-parser
@@ -178,37 +173,27 @@
   company: Postman
   isTscMember: true
   repos:
-    - avro-schema-parser
-    - openapi-schema-parser
-    - chatbot
     - diff
-    - cli
     - generator-filters
     - generator-hooks
     - github-action-for-generator
     - generator
     - nodejs-template
     - nodejs-ws-template
-    - parser-js
-    - playground
     - spec
     - spec-json-schemas
     - template-for-generator-templates
     - website
-    - bundler
 - name: Maciej Urbańczyk
   github: magicmatatjahu
   availableForHire: false
   linkedin: maciej-urbańczyk-909547164
   slack: U01EB02BP7A
-  company: Postman
+  company: Travelping GmbH
   isTscMember: true
   repos:
     - asyncapi-react
-    - chatbot
-    - cli
     - converter-go
-    - event-gateway
     - generator-react-sdk
     - generator
     - html-template
@@ -216,7 +201,6 @@
     - modelina
     - parser-js
     - parser-go
-    - playground
     - server-api
     - template-for-go-projects
     - website
@@ -234,8 +218,7 @@
   github: damaru-inc
   availableForHire: false
   slack: UH3B166TD
-  company: Solace
-  isTscMember: true
+  isTscMember: false
   repos:
     - java-spring-cloud-stream-template
     - python-paho-template
@@ -247,12 +230,9 @@
   linkedin: missy-turco-a476a6126
   availableForHire: false
   company: Postman
-  isTscMember: true
+  isTscMember: false
   repos:
     - brand
-    - design-system
-    - studio
-    - website
 - name: Nektarios Fifes
   github: nektariosfifes
   linkedin: nektarios-fifes-372740220
@@ -366,7 +346,6 @@
   slack: U02FP8WBFQE
   linkedin: danielr
   availableForHire: false
-  company: IBM
   isTscMember: true
   repos:
     - java-template
@@ -376,7 +355,7 @@
   availableForHire: false
   slack: U02FT2TKM37
   company: IBM
-  isTscMember: true
+  isTscMember: false
   repos:
     - java-template
 - name: Tom Jefferson
@@ -385,7 +364,7 @@
   slack: U02FPPCEH6H
   availableForHire: false
   company: IBM
-  isTscMember: true
+  isTscMember: false
   repos:
     - java-template
 - name: Lewis Relph
@@ -393,7 +372,7 @@
   availableForHire: false
   slack: U02G8MDDEF3
   company: IBM
-  isTscMember: true
+  isTscMember: false
   repos:
     - java-template
 - name: Semen Tenishchev
@@ -420,7 +399,7 @@
   linkedin: rondebajyoti
   availableForHire: false
   company: Narvar
-  isTscMember: true
+  isTscMember: false
   repos:
     - modelina
 - name: Ivan Garcia Sainz-Aja
@@ -458,7 +437,7 @@
   twitter: vladimirgorej
   availableForHire: false
   company: SmartBear
-  isTscMember: true
+  isTscMember: false
   repos:
     - bindings
     - spec


### PR DESCRIPTION
Since we have an automation for voting at the moment and it is easy to even manually check the participation from TSC, I could check who among TSC members did not participate recently.

I reached out to multiple TSC members and as a result we have this PR that refresh some info in TSC list, many responders made commitment that they want to stay (I also explained how easy it is to follow voting through dedicated subscription they can make on this page: https://www.asyncapi.com/community/tsc)

Current number of TSC members is 48 and will be 39 after we merge this PR (waiting for 1 more person to contact me). This means we should get a solid number of at least 38 people that voluntarily want to contribute to healthy growth of AsyncAPI Initiative.

New emeritus (people that are no longer TSC members - this has nothing to do with maintainership):
  - @mcturco - I had a chat with Missy 2 weeks ago. She cannot commit to TSC work and also will handover her repos to @Mayaleeeee 
  - @damaru-inc - Michael is no longer at Solace and also we need to start process of deciding what is next with python paho template
  - @geraldloeffler - https://github.com/asyncapi/community/pull/1276 but still supports as maintainer
  - @ron-debajyoti - https://github.com/asyncapi/community/pull/1277 but still supports as maintainer
  - @char0n - https://github.com/asyncapi/community/pull/1279 but still supports as maintainer
  - @kieranm1999 - no longer involved with AsyncAPI
  - @jefflufc - no longer involved with AsyncAPI
  - @lewis-relph - no longer involved with AsyncAPI
  - @emilianozublena - cannot for now do TSC work but will still help with php template when needed

I'd like to share a huge thanks to all the emeritus for all the help and remind that TSC is open for them as long as they still maintain one of AsyncAPI repositories.

👏🏼 

