### PR TITLE
fix: update invalid GitHub username for Alejandra Quetzalli

### DIFF
--- a/MAINTAINERS.yaml
+++ b/MAINTAINERS.yaml
@@ -319,7 +319,7 @@
     - cli
     - bundler
     - glee
-- name: Quetzalli 
+- name: Quetzalli Writes
   github: quetzalliwrites
   twitter: QuetzalliWrites
   slack: U02AKC14WAJ

--- a/MAINTAINERS.yaml
+++ b/MAINTAINERS.yaml
@@ -319,11 +319,11 @@
     - cli
     - bundler
     - glee
-- name: Alejandra Quetzalli
+- name: Quetzalli 
   github: quetzalliwrites
-  twitter: QuetzalliAle
+  twitter: QuetzalliWrites
   slack: U02AKC14WAJ
-  linkedin: alejandra-quetzalli
+  linkedin: quetzalli-writes
   availableForHire: false
   company: Postman
   isTscMember: true

--- a/MAINTAINERS.yaml
+++ b/MAINTAINERS.yaml
@@ -320,7 +320,7 @@
     - bundler
     - glee
 - name: Alejandra Quetzalli
-  github: alequetzalli
+  github: quetzalliwrites
   twitter: QuetzalliAle
   slack: U02AKC14WAJ
   linkedin: alejandra-quetzalli


### PR DESCRIPTION
**Description**

The maintainer's GitHub username has been changed. According to [this PR](https://github.com/asyncapi/website/pull/3084/files), the new username is `quetzalliwrites` instead of `alequetzalli`.

**Reason**

If this change is not made, the automation will remove the old entry and add a new one. While this may seem beneficial, all the manually set properties will be lost (slack, linkedin, etc.). Therefore, it's better to fix it before the automation.

cc @quetzalliwrites 

**Related issue(s)**

- https://github.com/asyncapi/community/issues/1269