### PR TITLE
fix(COC): typo in email address in Enforcement section

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -49,7 +49,7 @@ For more details, please see the [CoC Committee and Incident Resolution Procedur
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at condcut@asyncapi.io. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at conduct@asyncapi.io. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 


### PR DESCRIPTION
**Description**

- Typo in email address in Enforcement section: condcut@asyncapi.io → conduct@asyncapi.io

**Related issue(s)**

Resolves #1536
