### PR TITLE
fix: terraform setup added

### DIFF
--- a/.github/workflows/slack-integration.yml
+++ b/.github/workflows/slack-integration.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "^1.3.7"
+          terraform_wrapper: false   
       - name: Deploy changes to Slack
         run: |
           cd .github/workflows/slack


### PR DESCRIPTION
**Description**
This PR includes the necessary changes required in the new `ubuntu-latest` image used for the workflow to setup terraform.

As previously discussed with @Shurtu-gal in the issue #1658 the used action in the PR is `hashicorp/setup-terraform@v3 action` and i have tested it by creating a slack workspace and running the workflow similar to one mentioned in the issue.
Here is the [repository](https://github.com/neoandmatrix/terraform) for same.

**Related issue(s)**
Resolves #1658 

@Shurtu-gal please review and provide feedback on the PR.
Thanks.