### PR TITLE
docs: add GSoC 2025 project ideas

### DIFF
--- a/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
+++ b/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
@@ -72,7 +72,7 @@ Develop a new AsyncAPI Generator template for Java with Quarkus, leveraging its 
 
 
 2. **Is using ChatGPT for GSoC project proposals allowed?**
-   We advise against using ChatGPT or similar AI tools for your GSoC project proposals with AsyncAPI. Should you choose to use such tools, we require that this be fully disclosed in your application.
+  We advise against using ChatGPT or similar AI tools for your GSoC project proposals with AsyncAPI. If you choose to use such tools, we require that you fully disclose this in your application.
 
 3. **Where is the AsyncAPI source code located?**
    You can find all AsyncAPI source code on GitHub under our organization: [https://github.com/asyncapi](https://github.com/asyncapi).

--- a/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
+++ b/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
@@ -61,7 +61,7 @@ Develop a new AsyncAPI Generator template for Java with Quarkus, leveraging its 
 
 ## FAQ
 
-1. **How active are previous GSoC contributors in AsyncAPI?** AsyncAPI participated as a standalone organization in GSoC for the first time in 2024, after previously collaborating with Postman. Many contributors from that cohort remain actively involved in the community, including:
+1. **How active are previous GSoC contributors in AsyncAPI?** AsyncAPI participated as a standalone organization in GSoC for the first time in 2024 after previously collaborating with Postman. Many contributors from that cohort remain actively involved in the community, including:
 
    - **[@ashmit-coder](https://github.com/ashmit-coder)**: Now a maintainer of the [conference-website](https://github.com/asyncapi/conference-website) repository.
    - **[@helios2003](https://github.com/helios2003)**: Actively contributing to the [CLI](https://github.com/asyncapi/cli) and [Studio](https://github.com/asyncapi/studio) repositories.

--- a/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
+++ b/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
@@ -20,7 +20,7 @@ Build an AI-powered assistant fine-tuned on AsyncAPI to provide accurate answers
 - ⏳ **Length:** 175 Hours
 
 ## 3) [AsyncAPI Generator Maintainership](https://github.com/asyncapi/generator/issues/1360)
-This initiative aims to guide you on a journey from being a contributor to becoming a maintainer of the project. You'll gain insight into the responsibilities of a maintainer, involving tasks beyond mere coding.
+This initiative aims to guide you from contributing to maintaining the project. You'll gain insight into the responsibilities of a maintainer, which involve tasks beyond mere coding.
 
 - 🎯 **Outcome:** Taking responsibility for the project's future and continuous improvement.
 - 🛠️ **Skills:** JavaScript/TypeScript, testing libraries, Docker, virtualization, and test automation.

--- a/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
+++ b/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
@@ -1,0 +1,82 @@
+# AsyncAPI Ideas Page: Google Summer of Code 2024
+Welcome to the **AsyncAPI Ideas Page** with our proposed projects for Google Summer of Code (GSoC) 2024! If you are an interested student/contributor, please don't hesitate to contact our mentors directly to discuss project ideas.
+
+## 1) [Enhancing Performance and Reliability of AsyncAPI CLI](https://github.com/asyncapi/cli/issues/1657)
+Improve the AsyncAPI CLI by optimizing performance, enhancing test reliability, and introducing long-requested features such as publishing and syncing AsyncAPI files with remote repositories.
+
+- 🎯 **Outcome:** Achieve a faster CLI execution, stable tests, file sync/publish support, and enhanced validation.
+- 🛠️ **Skills Required:** JavaScript/TypeScript, Node.js, Testing Frameworks, API, and testing automation.
+- 🧩 **Difficulty:** Medium/Hard
+- 👩🏿‍🏫 **Mentor(s):** [@AayushSaini101](https://github.com/AayushSaini101) | [@Souvikns](https://github.com/Souvikns)
+- ⏳ **Length:** 175 Hours
+
+## 2) [AI-Powered Assistant for AsyncAPI](https://github.com/asyncapi/chatbot/issues/109)
+Build an AI-powered assistant fine-tuned on AsyncAPI to provide accurate answers, generate code snippets, debug specifications, and recommend best practices.
+
+- 🎯 **Outcome:** A fine-tuned LLM-powered chatbot integrated with AsyncAPI’s ecosystem for enhanced developer support.
+- 🛠️ **Skills Required:** Javascript/Typescript, Machine Learning (LLMs), NLP, OpenAI/Llama, Chatbot Integration.
+- 🧩 **Difficulty:** Medium/Hard
+- 👩🏿‍🏫 **Mentor(s):** [@AceTheCreator](https://github.com/AceTheCreator)
+- ⏳ **Length:** 175 Hours
+
+## 3) [AsyncAPI Generator Maintainership](https://github.com/asyncapi/generator/issues/1360)
+This initiative aims to guide you on a journey from being a contributor to becoming a maintainer of the project. You'll gain insight into the responsibilities of a maintainer, involving tasks beyond mere coding.
+
+- 🎯 **Outcome:** Taking responsibility for the project's future and continuous improvement.
+- 🛠️ **Skills:** JavaScript/TypeScript, testing libraries, Docker, virtualization, and test automation.
+- 🧩 **Difficulty:** Medium/Hard
+- 👩🏿‍🏫 **Mentor(s):** [@derberg](https://github.com/derberg)
+- ⏳ **Length:** 350 Hours
+
+## 4) [AsyncAPI Conference Website UI Kit Development](https://github.com/asyncapi/conference-website/issues/551)
+Develop a comprehensive UI Kit to enhance design consistency, modularity, and maintainability of the AsyncAPI Conference website.
+
+- 🎯 **Outcome:** A structured UI Kit with reusable components, Storybook integration, and improved design consistency.
+- 🛠️ **Skills Required:** React, TypeScript, Storybook, UI/UX Design, Component Development.
+- 🧩 **Difficulty:** Medium
+- 👩🏿‍🏫 **Mentor(s):** [@AceTheCreator](https://github.com/AceTheCreator)
+- ⏳ **Length:** 175 Hours
+
+## 5) [VS Code Extension Maintainership](https://github.com/asyncapi/conference-website/issues/551)
+This initiative will guide you from being a contributor to becoming a maintainer of the [VS Code AsyncAPI Preview extension](https://github.com/asyncapi/vs-asyncapi-preview). You'll learn the responsibilities of a maintainer, including code contributions, issue triaging, release management, and community engagement.
+
+- 🎯 **Outcome:** Taking ownership of the VS Code extension to ensure its long-term stability and improvement.
+- 🛠️ **Skills Required:** TypeScript/JavaScript, VS Code Extensions, Spectral Linting, Testing, and Open Source Contribution.
+- 🧩 **Difficulty:** Medium/Hard
+- 👩🏿‍🏫 **Mentor(s):** [@ivangsa](https://github.com/ivangsa)
+- ⏳ **Length:** 350 Hours
+
+## 6) Java + Quarkus Template for AsyncAPI Generator
+Develop a new AsyncAPI Generator template for Java with Quarkus, leveraging its growing adoption in cloud-native development.
+
+- 🎯 **Outcome:** A fully functional Java + Quarkus template for generating AsyncAPI-based applications.
+- 🛠️ **Skills Required:** Java, Quarkus, Templating Engines (Nunjucks/Handlebars), AsyncAPI Generator.
+- 🧩 **Difficulty:** Medium/Hard
+- 👩🏿‍🏫 **Mentor(s):** [@AayushSaini101](https://github.com/AayushSaini101), [@Souvikns](https://github.com/Souvikns)
+- ⏳ **Length:** 350 Hours
+
+## Contact AsyncAPI Mentors
+- Join [our Slack workspace](https://www.asyncapi.com/slack-invite).  Observe our [Slack etiquette](https://github.com/asyncapi/.github/blob/master/slack-etiquette.md) and [AsyncAPI code of conduct](https://github.com/asyncapi/.github/blob/master/CODE_OF_CONDUCT.md).
+- Join the dedicated Mentorship channel `#09_mentorships` to meet all other GSoC mentees and mentors.
+
+## FAQ
+
+1. **How active are previous GSoC contributors in AsyncAPI?**
+
+   AsyncAPI participated as a standalone organization in GSoC for the first time in 2024, after previously collaborating with Postman. Many contributors from that cohort remain actively involved in the community, including:
+
+   - **[@ashmit-coder](https://github.com/ashmit-coder)**: Now a maintainer of the [conference-website](https://github.com/asyncapi/conference-website) repository.
+   - **[@helios2003](https://github.com/helios2003)**: Actively contributing to the [CLI](https://github.com/asyncapi/cli) and [Studio](https://github.com/asyncapi/studio) repositories.
+   - **[@vishvamsinh28](https://github.com/vishvamsinh28)**: Active contributor and code reviewer in the [Website](https://github.com/asyncapi/website) and [conference-website](https://github.com/asyncapi/conference-website) repositories.
+
+   You can learn more about our GSoC 2024 participation in our official [blog post](https://www.asyncapi.com/blog/2024-gsoc-wrap).
+
+
+
+2. **Is using ChatGPT for GSoC project proposals allowed?**
+   We advise against using ChatGPT or similar AI tools for your GSoC project proposals with AsyncAPI. Should you choose to use such tools, we require that this be fully disclosed in your application.
+
+3. **Where is the AsyncAPI source code located?**
+   You can find all AsyncAPI source code on GitHub under our organization: [https://github.com/asyncapi](https://github.com/asyncapi).
+
+>If you have further questions or queries, please create an issue in this `/community` repo (with the prefix `GSoC 2025`) or start an [open AsyncAPI discussion](https://github.com/orgs/asyncapi/discussions).

--- a/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
+++ b/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
@@ -38,7 +38,7 @@ Develop a comprehensive UI Kit to enhance design consistency, modularity, and ma
 - ⏳ **Length:** 175 Hours
 
 ## 5) [VS Code Extension Maintainership](https://github.com/asyncapi/conference-website/issues/551)
-This initiative will guide you from being a contributor to becoming a maintainer of the [VS Code AsyncAPI Preview extension](https://github.com/asyncapi/vs-asyncapi-preview). You'll learn the responsibilities of a maintainer, including code contributions, issue triaging, release management, and community engagement.
+This initiative will guide you from contributing to becoming a maintainer of the [VS Code AsyncAPI Preview extension](https://github.com/asyncapi/vs-asyncapi-preview). You'll learn the responsibilities of a maintainer, including code contributions, issue triaging, release management, and community engagement.
 
 - 🎯 **Outcome:** Taking ownership of the VS Code extension to ensure its long-term stability and improvement.
 - 🛠️ **Skills Required:** TypeScript/JavaScript, VS Code Extensions, Spectral Linting, Testing, and Open Source Contribution.

--- a/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
+++ b/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
@@ -61,9 +61,7 @@ Develop a new AsyncAPI Generator template for Java with Quarkus, leveraging its 
 
 ## FAQ
 
-1. **How active are previous GSoC contributors in AsyncAPI?**
-
-   AsyncAPI participated as a standalone organization in GSoC for the first time in 2024, after previously collaborating with Postman. Many contributors from that cohort remain actively involved in the community, including:
+1. **How active are previous GSoC contributors in AsyncAPI?** AsyncAPI participated as a standalone organization in GSoC for the first time in 2024, after previously collaborating with Postman. Many contributors from that cohort remain actively involved in the community, including:
 
    - **[@ashmit-coder](https://github.com/ashmit-coder)**: Now a maintainer of the [conference-website](https://github.com/asyncapi/conference-website) repository.
    - **[@helios2003](https://github.com/helios2003)**: Actively contributing to the [CLI](https://github.com/asyncapi/cli) and [Studio](https://github.com/asyncapi/studio) repositories.

--- a/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
+++ b/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
@@ -1,4 +1,4 @@
-# AsyncAPI Ideas Page: Google Summer of Code 2024
+# AsyncAPI Ideas Page: Google Summer of Code 2025
 Welcome to the **AsyncAPI Ideas Page** with our proposed projects for Google Summer of Code (GSoC) 2024! If you are an interested student/contributor, please don't hesitate to contact our mentors directly to discuss project ideas.
 
 ## 1) [Enhancing Performance and Reliability of AsyncAPI CLI](https://github.com/asyncapi/cli/issues/1657)

--- a/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
+++ b/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
@@ -1,5 +1,5 @@
 # AsyncAPI Ideas Page: Google Summer of Code 2025
-Welcome to the **AsyncAPI Ideas Page** with our proposed projects for Google Summer of Code (GSoC) 2024! If you are an interested student/contributor, please don't hesitate to contact our mentors directly to discuss project ideas.
+Welcome to the **AsyncAPI Ideas Page** with our proposed projects for Google Summer of Code (GSoC) 2025! If you are an interested contributor, please don't hesitate to contact our mentors directly to discuss project ideas.
 
 ## 1) [Enhancing Performance and Reliability of AsyncAPI CLI](https://github.com/asyncapi/cli/issues/1657)
 Improve the AsyncAPI CLI by optimizing performance, enhancing test reliability, and introducing long-requested features such as publishing and syncing AsyncAPI files with remote repositories.

--- a/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
+++ b/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
@@ -22,7 +22,7 @@ Build an AI-powered assistant fine-tuned on AsyncAPI to provide accurate answers
 ## 3) [AsyncAPI Generator Maintainership](https://github.com/asyncapi/generator/issues/1360)
 This initiative aims to guide you from contributing to maintaining the project. You'll gain insight into the responsibilities of a maintainer, which involve tasks beyond mere coding.
 
-- 🎯 **Outcome:** Taking responsibility for the project's future and continuous improvement.
+- 🎯 **Outcome:** Responsible for the project's future and continuous improvement.
 - 🛠️ **Skills:** JavaScript/TypeScript, testing libraries, Docker, virtualization, and test automation.
 - 🧩 **Difficulty:** Medium/Hard
 - 👩🏿‍🏫 **Mentor(s):** [@derberg](https://github.com/derberg)


### PR DESCRIPTION
Curated a list of selected project ideas for our participation in the 2025 Google Summer of Code edition