### PR TITLE
ci: update process of passing auth token

### DIFF
--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -6,9 +6,6 @@ on:
     paths: 
       - 'MAINTAINERS.yaml'
 
-env:
-  GH_TOKEN_ORG_ADMIN: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
-
 jobs:
   detect_maintainer_changes:
     if: github.event.pull_request.merged 
@@ -95,7 +92,7 @@ jobs:
       - name: Invite new maintainers to the organization
         uses: actions/github-script@v6
         with:
-          github-token: ${{ env.GH_TOKEN_ORG_ADMIN }}
+          github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
             const newMaintainers = '${{ needs.detect_maintainer_changes.outputs.newMaintainers }}'.split(',');
             for (const maintainer of newMaintainers) {
@@ -112,7 +109,7 @@ jobs:
       - name: Add new maintainers to the team
         uses: actions/github-script@v6
         with:
-          github-token: ${{ env.GH_TOKEN_ORG_ADMIN }}
+          github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
             const newMaintainers = '${{ needs.detect_maintainer_changes.outputs.newMaintainers }}'.split(',');
             for (const maintainer of newMaintainers) {
@@ -138,7 +135,7 @@ jobs:
       - name: Display welcome message for new maintainers
         uses: actions/github-script@v6
         with:
-          github-token: ${{ env.GH_TOKEN_ORG_ADMIN }}
+          github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
             const newMaintainers = "${{ needs.add_maintainer.outputs.newMaintainers }}".split(",");
             console.log(`New maintainers: ${newMaintainers}`);
@@ -162,7 +159,7 @@ jobs:
       - name: Remove maintainers from the organization
         uses: actions/github-script@v6
         with:
-          github-token: ${{ env.GH_TOKEN_ORG_ADMIN }}
+          github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
             const removedMaintainers = '${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}'.split(',');
             for (const maintainer of removedMaintainers) {
@@ -189,7 +186,7 @@ jobs:
       - name: Display goodbye message to removed maintainers
         uses: actions/github-script@v6
         with:
-          github-token: ${{ env.GH_TOKEN_ORG_ADMIN }}
+          github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
               const removedMaintainers = "${{ needs.remove_maintainer.outputs.removedMaintainers }}".split(",");
               const removedTscMembers = "${{ needs.remove_maintainer.outputs.removedTscMembers }}".split(",");
@@ -220,7 +217,7 @@ jobs:
       - name: Add TSC members to Emeritus.yaml and print
         uses: actions/github-script@v6
         with:
-          github-token: ${{ env.GH_TOKEN_ORG_ADMIN }}
+          github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
             const fs = require('fs');
             const path = './Emeritus.yaml';
@@ -252,7 +249,7 @@ jobs:
         run: |
           git add .
           git commit -m "chore: update Emeritus.yaml"
-          git remote set-url origin https://x-access-token:${{ env.GH_TOKEN_ORG_ADMIN }}@github.com/asyncapi/community.git
+          git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN_ORG_ADMIN }}@github.com/asyncapi/community.git
           git push origin update-emeritus-${{ github.run_id }}
 
       - name: Create PR

--- a/.github/workflows/maintainers-tsc-changes-verification.yaml
+++ b/.github/workflows/maintainers-tsc-changes-verification.yaml
@@ -33,7 +33,7 @@ jobs:
         id: verify-changes
         uses: actions/github-script@v6
         with:
-          github-token: ${{ env.GH_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const yaml = require("js-yaml");
             const fs = require("fs");
@@ -123,7 +123,7 @@ jobs:
       - name: Comment and close the PR if there are any critical changes done by human
         uses: actions/github-script@v6
         with:
-          github-token: ${{ env.GH_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const errorMessagesString = `${{ needs.verify-changes-if-tsc-if-maintainers.outputs.errorMessages }}`;
             const errorMessages = errorMessagesString ? JSON.parse(errorMessagesString) : [];
@@ -159,7 +159,7 @@ jobs:
         if: steps.verify-changes-if-tsc-if-maintainers.outputs.removedTscMembers != ''
         uses: actions/github-script@v6
         with:
-          github-token: ${{ env.GH_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
               const issueComment = {
                   owner: github.context.repo.owner,


### PR DESCRIPTION
This PR updates the process of passing the authorization token to `with.github-token` by changing it from being passed through `env:` to being passed directly via the `secrets` property.

Related to https://github.com/asyncapi/community/issues/1620