### PR TITLE
chore: add correct link  for vscode extension maintainership

### DIFF
--- a/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
+++ b/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md
@@ -37,7 +37,7 @@ Develop a comprehensive UI Kit to enhance design consistency, modularity, and ma
 - 👩🏿‍🏫 **Mentor(s):** [@AceTheCreator](https://github.com/AceTheCreator)
 - ⏳ **Length:** 175 Hours
 
-## 5) [VS Code Extension Maintainership](https://github.com/asyncapi/conference-website/issues/551)
+## 5) [VS Code Extension Maintainership](https://github.com/asyncapi/vs-asyncapi-preview/issues/253)
 This initiative will guide you from contributing to becoming a maintainer of the [VS Code AsyncAPI Preview extension](https://github.com/asyncapi/vs-asyncapi-preview). You'll learn the responsibilities of a maintainer, including code contributions, issue triaging, release management, and community engagement.
 
 - 🎯 **Outcome:** Taking ownership of the VS Code extension to ensure its long-term stability and improvement.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- The [link](https://github.com/asyncapi/community/blob/master/mentorship/summerofcode/2025/asyncapi-gsoc-ideas-page.md#5-vs-code-extension-maintainership) for the project - `vscode extension maintainership` does not point to the [correct link](https://github.com/asyncapi/vs-asyncapi-preview/issues/253)

**Related issue(s)**
Closes #1718