### PR TITLE
docs: add AsyncAPI Style Guide to documentation

### DIFF
--- a/docs/onboarding-guide/contribute-to-docs.md
+++ b/docs/onboarding-guide/contribute-to-docs.md
@@ -10,3 +10,7 @@ There are several ways to request your first AsyncAPI docs task:
 1. **Connect with a docs maintainer:** Ask for a `good-first-issue` in the `#13_docs` channel of the [AsyncAPI Slack](https://www.asyncapi.com/slack-invite) workspace. 
 2. **Update current docs:** Surf the existing documentation, look for `typos`, `grammar`, `errors`, create an issue, and submit a Pull Request. 
 3. **Propose new docs:** If you have any ideas or suggestions for necessary documentation, [create a new docs issue](https://github.com/asyncapi/website/issues/new?labels=%F0%9F%93%91+docs&projects=&template=docs.yml&title=%5B%F0%9F%93%91+Docs%5D%3A+) and propose yourself as the assignee. 
+
+## Follow the AsyncAPI Style Guide
+
+To ensure consistency and clarity in our documentation, please follow the [AsyncAPI Style Guide](https://github.com/asyncapi/community/pulls?q=is%3Apr+is%3Aopen+style+guide). The style guide includes guidelines on accessibility, code examples, content organization, inclusive language, voice and tone, grammar, numbers, punctuation, formatting, internalization, links, SEO, styling, version control, and glossary.

--- a/docs/onboarding-guide/create-new-docs-directories.md
+++ b/docs/onboarding-guide/create-new-docs-directories.md
@@ -22,3 +22,7 @@ flowchart LR
     B[new Folder] --> E[example-doc-1.md]
     B[new Folder] --> F[example-doc-2.md]
 ```
+
+### Follow the AsyncAPI Style Guide
+
+To ensure consistency and clarity in our documentation, please follow the [AsyncAPI Style Guide](https://github.com/asyncapi/community/pulls?q=is%3Apr+is%3Aopen+style+guide). The style guide includes guidelines on accessibility, code examples, content organization, inclusive language, voice and tone, grammar, numbers, punctuation, formatting, internalization, links, SEO, styling, version control, and glossary.

--- a/docs/onboarding-guide/docs-community.md
+++ b/docs/onboarding-guide/docs-community.md
@@ -22,6 +22,6 @@ Stay tuned for new opportunities on our [Docs’ Community discussions](https://
 
 | Docs Roadmap | Ongoing Docs Projects | Timeline | Contribution Type |
 |--------------|-----------------------|----------|---------------------|
-| AsyncAPI Style Guide | [AsyncAPI Style Guide](https://github.com/asyncapi/website/issues/1240) | Ongoing | Regular contribution |
+| AsyncAPI Style Guide | [AsyncAPI Style Guide](https://github.com/asyncapi/website/issues/1240) | Completed | Regular contribution |
 | AsyncAPI Tools’ Docs | <li>[Modelina Docs](https://github.com/asyncapi/modelina/tree/master/docs) </li>  <li>[Parser Docs](https://github.com/asyncapi/parser-js/tree/master/docs) </li> <li>[GitHub Actions Docs](https://github.com/asyncapi/github-action-for-generator)</li> <li>[Studio Docs](https://github.com/asyncapi/studio/tree/master/doc/adr)</li> <li>[Generator Docs](https://github.com/asyncapi/generator/tree/master/docs)</li> <li>[CLI Docs](https://github.com/asyncapi/cli/tree/master/docs)</li> | Ongoing | Regular contribution |
 | Technical Writer Onboarding Guide | Onboarding Guide for new docs contributors | Ongoing | Regular contribution |

--- a/docs/onboarding-guide/docs-onboarding-checklist.md
+++ b/docs/onboarding-guide/docs-onboarding-checklist.md
@@ -14,7 +14,7 @@ Complete in order the following onboarding tasks:
 - [ ] Add the AsyncAPI calendar found in [the AsyncAPI events page](https://www.asyncapi.com/community/events).
 - [ ] Read the list of [technical writer contributor responsibilities](technical-writer-contributor-responsibilities).
 - [ ] Read and familiarize yourself with the [prerequisite knowledge topics](prerequisite-knowledge).
-- [ ] Familiarize yourself with the _work-in-progress_ [AsyncAPI Style Guide](https://github.com/asyncapi/community/pulls?q=is%3Apr+is%3Aopen+style+guide).
+- [ ] Familiarize yourself with the completed [AsyncAPI Style Guide](https://github.com/asyncapi/community/pulls?q=is%3Apr+is%3Aopen+style+guide).
 - [ ] Read all docs under the following content buckets: `Concepts`, `Tutorials`, `Reference`. (Take the time to go through each tutorial.)
 - [ ] Set up your local environment following our instructions for the [AsyncAPI git workflow](https://github.com/asyncapi/community/blob/master/git-workflow.md).
 - [ ] Introduce yourself in AsyncAPI Slack in the `#01_introductions` channel and the `#13_docs` channel. Ask docs-related questions in #13_docs.

--- a/docs/onboarding-guide/index.md
+++ b/docs/onboarding-guide/index.md
@@ -18,5 +18,6 @@ The goal is providing docs contributors with the necessary tools and knowledge t
 * Obtain and incorporate reviewers' feedback.
 * Publish changes successfully.
 
+## AsyncAPI Style Guide
 
-
+To ensure consistency and clarity in our documentation, please follow the [AsyncAPI Style Guide](https://github.com/asyncapi/community/pulls?q=is%3Apr+is%3Aopen+style+guide). The style guide includes guidelines on accessibility, code examples, content organization, inclusive language, voice and tone, grammar, numbers, punctuation, formatting, internalization, links, SEO, styling, version control, and glossary.

--- a/docs/onboarding-guide/open-docs-pull-request.md
+++ b/docs/onboarding-guide/open-docs-pull-request.md
@@ -13,3 +13,7 @@ Create and submit a docs pull request (PR) via the following steps:
 - Tag other technical writers to review your document. 
 - Tag an engineer or subject matter expert (SME) to review the technical details.
 - After implementing all the feedback you requested, please update your PR and wait for further feedback before it can be merged.
+
+### Ensure Compliance with the AsyncAPI Style Guide
+
+To ensure consistency and clarity in our documentation, please follow the [AsyncAPI Style Guide](https://github.com/asyncapi/community/pulls?q=is%3Apr+is%3Aopen+style+guide). The style guide includes guidelines on accessibility, code examples, content organization, inclusive language, voice and tone, grammar, numbers, punctuation, formatting, internalization, links, SEO, styling, version control, and glossary.

--- a/docs/onboarding-guide/prerequisite-knowledge.md
+++ b/docs/onboarding-guide/prerequisite-knowledge.md
@@ -34,3 +34,7 @@ Because an AsyncAPI definition can be written in JSON and YAML, you must learn h
 
 ## Protocols used with AsyncAPI
 AsyncAPI supports several protocols, such as Kafka, AMQP, MQTT, and more. You will benefit from acquiring a [basic understanding of protocols most used with AsyncAPI](https://www.asyncapi.com/docs/concepts/protocol), including their use cases and how they work with AsyncAPI. 
+
+## AsyncAPI Style Guide
+
+To ensure consistency and clarity in our documentation, please follow the [AsyncAPI Style Guide](https://github.com/asyncapi/community/pulls?q=is%3Apr+is%3Aopen+style+guide). The style guide includes guidelines on accessibility, code examples, content organization, inclusive language, voice and tone, grammar, numbers, punctuation, formatting, internalization, links, SEO, styling, version control, and glossary.

--- a/docs/onboarding-guide/technical-writer-contributor-responsibilities.md
+++ b/docs/onboarding-guide/technical-writer-contributor-responsibilities.md
@@ -12,3 +12,4 @@ Technical writer contributor responsibilities include:
 * Support fellow technical writers and community members.
 * Engage in documentation review processes and incorporate feedback.
 * Join documentation community meetings/streams to connect with the community.
+* Adhere to the [AsyncAPI Style Guide](https://github.com/asyncapi/community/pulls?q=is%3Apr+is%3Aopen+style+guide) to ensure consistency and clarity in our documentation.


### PR DESCRIPTION
Fixes #1683

Update documentation to include the completed AsyncAPI Style Guide.

* Update `docs/onboarding-guide/docs-onboarding-checklist.md` to reference the completed AsyncAPI Style Guide and add a link.
* Update `docs/onboarding-guide/docs-community.md` to list the AsyncAPI Style Guide as a completed project and add a link.
* Add a section on following the AsyncAPI Style Guide in `docs/onboarding-guide/contribute-to-docs.md` and include a link.
* Add a reference to the AsyncAPI Style Guide for naming conventions and structure in `docs/onboarding-guide/create-new-docs-directories.md` and include a link.
* Mention the AsyncAPI Style Guide as a key resource in `docs/onboarding-guide/index.md` and include a link.
* Add a step to ensure compliance with the AsyncAPI Style Guide in `docs/onboarding-guide/open-docs-pull-request.md` and include a link.
* Add the AsyncAPI Style Guide as required reading in `docs/onboarding-guide/prerequisite-knowledge.md` and include a link.
* Add adherence to the AsyncAPI Style Guide as a responsibility in `docs/onboarding-guide/technical-writer-contributor-responsibilities.md` and include a link.

