### PR TITLE
docs: add styling guide guide to AsyncAPI Style Guide

### DIFF
--- a/asyncapi.com/docs/community/styleguide/styling.md
+++ b/asyncapi.com/docs/community/styleguide/styling.md
@@ -1,0 +1,51 @@
+# AsyncAPI Style Guide: Styling
+
+## CSS Code Styling Guidelines
+
+- Use BEM (Block Element Modifier) methodology for naming CSS classes.
+- Avoid using IDs for styling purposes.
+- Use variables for colors, fonts, and other reusable values.
+- Keep CSS specificity low to avoid conflicts.
+- Use flexbox or grid for layout purposes.
+- Ensure CSS is responsive and works well on different screen sizes.
+
+## Font Size Guidelines
+
+- Use relative units (em, rem) instead of absolute units (px) for font sizes.
+- Base font size should be 16px (1rem).
+- Headings should follow a consistent scale, e.g., h1: 2rem, h2: 1.75rem, h3: 1.5rem, etc.
+- Ensure sufficient contrast between text and background for readability.
+
+## Markdown Styling Guidelines
+
+- Use proper heading levels (h1, h2, h3, etc.) for document structure.
+- Use bullet points or numbered lists for lists.
+- Use backticks for inline code and triple backticks for code blocks.
+- Use blockquotes for quotes or important notes.
+- Use horizontal rules (---) to separate sections.
+
+## Lists, Images, Diagrams, and Tables Styling Guidelines
+
+### Lists
+
+- Use bullet points for unordered lists and numbers for ordered lists.
+- Indent nested lists properly for clarity.
+- Keep list items concise and to the point.
+
+### Images
+
+- Use descriptive alt text for all images.
+- Ensure images are responsive and scale properly on different screen sizes.
+- Use appropriate file formats (e.g., PNG, JPEG, SVG) based on the image type.
+
+### Diagrams
+
+- Use vector-based formats (e.g., SVG) for diagrams whenever possible.
+- Ensure diagrams are clear and legible.
+- Provide a brief description or caption for each diagram.
+
+### Tables
+
+- Use tables for tabular data only.
+- Ensure tables are responsive and scrollable on smaller screens.
+- Use proper table headers (th) and data cells (td) for accessibility.


### PR DESCRIPTION
Fixes #1698

Add a new Styling section to the AsyncAPI Style Guide.

* **Styling Guidelines**
  - Create a new file `asyncapi.com/docs/community/styleguide/styling.md`.
  - Add CSS code styling guidelines.
  - Add font size guidelines.
  - Add markdown styling guidelines.
  - Add lists, images, diagrams, and tables styling guidelines.

