### PR TITLE
docs: add Internalization (i18n) & Localization section to AsyncAPI Style Guide

### DIFF
--- a/asyncapi.com/docs/community/styleguide/i18n-localization.md
+++ b/asyncapi.com/docs/community/styleguide/i18n-localization.md
@@ -1,0 +1,41 @@
+# Internalization (i18n) & Localization
+
+## Introduction
+
+Internalization (i18n) and Localization are essential for ensuring that AsyncAPI documentation meets the language and cultural needs of new regions and multiple locales. This section provides guidelines for achieving this goal.
+
+## Guidelines
+
+### Language Support
+
+1. **Identify Target Languages**: Determine the languages that are most relevant to your audience.
+2. **Translation Quality**: Ensure high-quality translations by using professional translators or translation services.
+3. **Consistency**: Maintain consistency in terminology and style across all translations.
+
+### Cultural Adaptation
+
+1. **Cultural Relevance**: Adapt content to be culturally relevant to the target audience.
+2. **Date and Time Formats**: Use date and time formats that are familiar to the target audience.
+3. **Units of Measurement**: Use units of measurement that are commonly used in the target locale.
+
+### Technical Considerations
+
+1. **Character Encoding**: Use UTF-8 encoding to support a wide range of characters.
+2. **Right-to-Left Languages**: Ensure that the documentation layout supports right-to-left languages if needed.
+3. **Locale-Specific Content**: Provide locale-specific content where necessary, such as legal disclaimers or regulatory information.
+
+### Testing and Validation
+
+1. **Language Testing**: Test translations with native speakers to ensure accuracy and readability.
+2. **Cultural Testing**: Validate that the content is culturally appropriate and relevant.
+3. **Technical Testing**: Ensure that the documentation functions correctly in different locales and languages.
+
+## Resources
+
+For best practices and additional guidelines, refer to the following resources:
+- [Write the Docs: Style Guides](https://www.writethedocs.org/guide/writing/style-guides/)
+- [Gatsby Style Guide](https://www.gatsbyjs.com/contributing/gatsby-style-guide/)
+- [Gatsby Docs Structure & Documentation Types](https://www.gatsbyjs.com/contributing/docs-contributions/docs-structure/)
+- [Mozilla Style Guide](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Writing_style_guide)
+- [Google Style Guide](https://developers.google.com/style)
+- [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)


### PR DESCRIPTION
Fixes #1695

Add Internalization (i18n) & Localization section to AsyncAPI Style Guide.

* Create a new directory `asyncapi.com/docs/community/styleguide/`.
* Add a new file `i18n-localization.md` in the `styleguide` directory.
* Include guidelines for Internalization (i18n) & Localization in the `i18n-localization.md` file.
* Reference extra resources for best practices in the `i18n-localization.md` file.

