### PR TITLE
docs: add formatting section to AsyncAPI Style Guide

### DIFF
--- a/asyncapi.com/docs/community/styleguide/formatting.md
+++ b/asyncapi.com/docs/community/styleguide/formatting.md
@@ -1,0 +1,21 @@
+# AsyncAPI Style Guide: Formatting
+
+## Notes and Warning Blocks
+- Use blockquotes for notes and warnings.
+- Use a consistent style for notes and warnings throughout the documentation.
+- Example:
+  > **Note:** This is a note.
+  > **Warning:** This is a warning.
+
+## Code Blocks
+- Use triple backticks for code blocks.
+- Specify the language for syntax highlighting.
+- Example:
+  ```javascript
+  console.log('Hello, world!');
+  ```
+
+## White Space
+- Use white space to improve readability.
+- Use blank lines to separate sections and paragraphs.
+- Use indentation to indicate hierarchy and structure.


### PR DESCRIPTION
Fixes #1694

Add a new `.md` file for the Formatting section of the AsyncAPI Style Guide.

* Create a new file `formatting.md` in the `asyncapi.com/docs/community/styleguide/` directory.
* Add a title "AsyncAPI Style Guide: Formatting" at the top of the file.
* Add a section for "Notes and Warning Blocks" with guidelines for formatting notes and warning blocks.
* Add a section for "Code Blocks" with guidelines for formatting code blocks.
* Add a section for "White Space" with guidelines for using white space in documentation.

