### PR TITLE
docs: add Grammar section to AsyncAPI Style Guide

### DIFF
--- a/asyncapi.com/docs/community/styleguide/grammar.md
+++ b/asyncapi.com/docs/community/styleguide/grammar.md
@@ -1,0 +1,32 @@
+# AsyncAPI Style Guide: Grammar
+
+## Abbreviations and Acronyms
+
+Use abbreviations and acronyms sparingly. When first introducing an abbreviation or acronym, spell it out in full followed by the abbreviation or acronym in parentheses. For example, "Representational State Transfer (REST)". After the first mention, you can use the abbreviation or acronym alone.
+
+## Active Voice
+
+Use active voice whenever possible. Active voice makes your writing clearer and more direct. For example, instead of writing "The code was written by the developer," write "The developer wrote the code."
+
+## Capitalization
+
+Capitalize titles, headings, and specific terms according to the following rules:
+- Capitalize the first and last words of titles and headings.
+- Capitalize all major words in titles and headings, including nouns, pronouns, verbs, adjectives, adverbs, and some conjunctions.
+- Do not capitalize articles (a, an, the), coordinating conjunctions (and, but, or, nor, for, so, yet), and short prepositions (in, on, at, to, by, up, for, off, etc.) unless they are the first or last word of the title or heading.
+- Capitalize specific terms such as "AsyncAPI", "JSON", "HTTP", etc.
+
+## Spelling
+
+Follow standard American English spelling conventions. Here are some preferred spellings for specific terms:
+- Use "color" instead of "colour".
+- Use "organize" instead of "organise".
+- Use "program" instead of "programme".
+- Use "center" instead of "centre".
+
+## Verb Tense
+
+Use present tense for general statements and descriptions. Use past tense for actions that have been completed. Use future tense for actions that will occur. For example:
+- Present tense: "The AsyncAPI specification defines the structure of the API."
+- Past tense: "The developer wrote the code."
+- Future tense: "The new feature will be released next month."


### PR DESCRIPTION
Fixes #1691

Add a new Grammar section to the AsyncAPI Style Guide.

* **Create new file**: Add `asyncapi.com/docs/community/styleguide/grammar.md` to house the Grammar section.
* **Abbreviations and Acronyms**: Define guidelines for using abbreviations and acronyms.
* **Active Voice**: Explain the importance of using active voice and provide examples.
* **Capitalization**: Detail rules for capitalizing titles, headings, and specific terms.
* **Spelling**: List common spelling conventions and preferred spellings for specific terms.
* **Verb Tense**: Outline appropriate verb tenses to use in different contexts.

