### PR TITLE
docs: fix broken link for asyncapi.com

### DIFF
--- a/mentorship/summerofcode/README.md
+++ b/mentorship/summerofcode/README.md
@@ -33,7 +33,7 @@ TL;DR: GSoC exclusively focuses on coding projects. While initiatives like docum
   For feedback, submit your work early! However, due to the influx of applications, feedback may only be available during the final week after the deadline.
 
 ### Getting Started with AsyncAPI
-- New to AsyncAPI? Visit the [AsyncAPI website](asyncapi.com) to learn more about the initiative.
+- New to AsyncAPI? Visit the [AsyncAPI website](https://www.asyncapi.com/) to learn more about the initiative.
 - Visit the [Community section](https://www.asyncapi.com/community) of the website to learn about the community behind AsyncAPI.
 - Explore all the active projects in the organization by visiting our [GitHub org](https://github.com/asyncapi).
 - Consider tackling one of the good first issues, resolving a bug, or enhancing existing features by visiting our [Issues Dashboard](https://www.asyncapi.com/community/dashboard). Include links to your past contributions to AsyncAPI in your proposal. Stay calm! If you're new to navigating a large codebase, we are here to help you 😊.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

The link to the website of AsyncAPI was written without `https://` and so was interpreted as relative to the current path, leading to 404 error. This PR fixes the link.
