### PR TITLE
ci: make sure core is removed when notify tsc

### DIFF
--- a/.github/workflows/vote-notify.yml
+++ b/.github/workflows/vote-notify.yml
@@ -89,7 +89,6 @@ jobs:
           script: |
             const yaml = require('js-yaml');
             const fs = require('fs');
-            const core = require('@actions/core');
             const {
               filterIssues,
               getTSCLeftToVote,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the notification script in the GitHub Actions workflow by removing a module import. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->