### PR TITLE
docs: update format of AMBASSADORS_MEMBERS.json

### DIFF
--- a/AMBASSADORS_MEMBERS.json
+++ b/AMBASSADORS_MEMBERS.json
@@ -5,6 +5,8 @@
     "bio": "Quetzalli Writes is an author of the book titled 'Docs-as-Ecosystem', which was published by the Apress Publishing Company. Quetzalli has been in tech for 9 years, working with SEO, Paid Search, Full-Stack development, UX, Developer Relations, and Technical Writing (Engineering Documentation). She's currently a core OSS contributor for Docs, DevRel, and Community Building at AsyncAPI Initiative. She's also a member of the AsyncAPI Technical Steering Committee (TSC).",
     "title": "DevRel & DevDocs @AsyncAPI",
     "github": "quetzalliwrites",
+    "githubID": "19964402",
+    "slack": "U02AKC14WAJ",
     "twitter": "QuetzalliWrites",
     "linkedin": "quetzalli-writes",
     "company": "Postman",
@@ -54,13 +56,15 @@
     "bio": "Daniel has been part of the codecentric team since October 2016. Since the beginning of 2022 he works as Senior Solution Architect at the Dortmund branch. Starting as a consultant with a focus on application lifecycle management, his focus shifted more and more towards APIs. In addition to numerous customer projects and his involvement in the open source world around APIs, our Head of API Experience & Operations is also a frequent speaker at conferences.",
     "title": "Senior Solution Architect / Head of API Experience and Operations",
     "github": "danielkocot",
+    "githubID": "466609",
+    "slack": "U029F3XUYM8",
     "twitter": "dk_1977",
     "linkedin": "danielkocot",
     "company": "Codecentric AG",
     "country": "🇩🇪",
     "contributions": [
       {
-	"type": "article",
+        "type": "article",
         "title": "AsyncAPI - Documentation of event and message-driven architectures",
         "date": {
           "year": 2021,
@@ -100,6 +104,8 @@
   {
     "name": "Giri Venkatesan",
     "github": "gvensan",
+    "githubID": "4477169",
+    "slack": "U02MHRKL2G2",
     "twitter": "giri_venkatesan",
     "country": "🇮🇳",
     "bio": "Giri Venkatesan, a follower and proponent of AsyncAPI and teams up with companies & SIs to design event-driven architecture and asynchronous APIs. To guide those discussions, I draw upon years of integration and implementation experience, particularly with Solace platforms. I've been a follower of AsyncAPI since 2022, and written blogs and delivered talks at conferences and AsyncAPI confrence tours.",
@@ -151,6 +157,8 @@
     "img": "https://avatars.githubusercontent.com/u/1001939?v=4",
     "bio": "Hugo Guerrero is a developer advocate for APIs and Event-driven Architecture. He assists organizations in this role by creating, editing, and curating product content shared with the community through webinars, conferences, and other activities. He works on open source software with major private and federal public sector clients looking to connect and extend their system architecture. He has over 20 years of experience as a developer, consultant, architect, and software development manager.",
     "github": "hguerrero",
+    "githubID": "1001939",
+    "slack": "U01H9D8J4H1",
     "twitter": "hguerreroo",
     "title": "Head of Technical Marketing",
     "linkedin": "hugoguerrero",
@@ -206,6 +214,8 @@
   {
     "name": "Ivan Garcia Sainz-Aja",
     "github": "ivangsa",
+    "githubID": "1246876",
+    "slack": "UTCN3ET4M",
     "twitter": "ivangsa",
     "bio": "Java Architect with a deep understanding of Java, Spring-Boot, Spring-Cloud technologies, specializing in Domain-Driven Design (DDD) and Event-Driven Architectures creating Software Easy to Understand. Building ZenWave 360º. ZenWave 360º is a set of tools built on the foundations of Domain Driven Design and API-First principles for Event-Driven Architectures, to help you create software easy to understand. https://www.zenwave360.io/",
     "linkedin": "ivangarciasainzaja",
@@ -290,6 +300,8 @@
   {
     "name": "Ludovic Dussart",
     "github": "M3lkior",
+    "githubID": "5501911",
+    "slack": "U01BM49KL3Z",
     "twitter": "ldussart",
     "country": "🇫🇷",
     "bio": "Ludovic is a Solutions Architect, working with his customers to build EDA-oriented digital products wherever possible. His first contributions to AsyncAPI date back to 2020 around the kafka and avro specifications. Since then, Ludovic has been spreading the word about AsyncAPI to companies in Northern France, to accelerate adoption of the initiative.",
@@ -419,6 +431,8 @@
   {
     "name": "Hari Krishnan",
     "github": "harikrishnan83",
+    "githubID": "126087",
+    "slack": "U067JPY0UH5",
     "twitter": "harikrishnan83",
     "linkedin": "harikrishnan83",
     "country": "🇮🇳",
@@ -468,6 +482,8 @@
   {
     "name": "Manuel Ottlik",
     "github": "manuelottlik",
+    "githubID": "28919003",
+    "slack": "U07GXSEH0E6",
     "twitter": "",
     "linkedin": "manuelottlik",
     "country": "🇩🇪",
@@ -547,6 +563,8 @@
     "title": "APIs and Open Source",
     "img": "https://lornajane.net/wp-content/uploads/2011/08/IMG_9410-smaller.jpg",
     "github": "lornajane",
+    "githubID": "172607",
+    "slack": "U017NCG83AQ",
     "twitter": "lornajane",
     "linkedin": "lornajane",
     "company": "Redocly",
@@ -584,6 +602,8 @@
   {
     "name": "Laurent Broudoux",
     "github": "lbroudoux",
+    "githubID": "1538635",
+    "slack": "U018NLDV5E1",
     "twitter": "lbroudoux",
     "country": "🇫🇷",
     "bio": "Laurent is a Cloud-Native Architecture expert and Enterprise Integration problem lover. He is the founder and lead developer of the Microcks.io open-source project: a cloud-native tool for API mocking and testing. For this, he is using his 10+ years experience as an architect in Financial Services where he defined API transformation strategies, including governance and delivery process.",

--- a/AMBASSADOR_ORGANIZATION.md
+++ b/AMBASSADOR_ORGANIZATION.md
@@ -55,6 +55,17 @@ Examples:
 
 The process of becoming an ambassador is very simple. Go to the **community** repository and open a PR to edit the `AMBASSADORS_MEMBERS.json` file. The TSC will then evaluate your candidacy!
 
+> **The process of obtaining the GitHub ID number**
+> - The Ambassador Candidate adds their GitHub handle to `https://api.github.com/users/` to form link similar to https://api.github.com/users/derberg and puts into the browser's address bar.
+> - Presses Enter.
+> - API returns a JSON object in which property `id` equals a number (in the case of the example, the number is `6995927`). This is the number that the Ambassador Candidate needs to insert as the value of the property `githubID` in the `AMBASSADORS_MEMBERS.json` file.
+
+> **The process of obtaining the Slack ID number**
+> - The Ambassador Candidate finds themselves in the members list of the Slack channel `02_general`.
+> - Presses on their handle.
+> - In the opened `Profile` window, presses the button with three dots.
+> - Chooses the option `Copy member ID`. This is the sequence of characters that the Ambassador Candidate needs to insert as the value of the property `slack` in the `AMBASSADORS_MEMBERS.json` file.
+
 That PR doesn't have to be created by the ambassador candidate; any community member may open a PR to submit someone's application to the AsyncAPI Ambassador Program. 
 
 Get on board and become an ambassador!


### PR DESCRIPTION
This PR:
- Updates the format of the `AMBASSADORS_MEMBERS.json` file to include the properties:
  - `githubID`
  - `slack`
- Adds to `AMBASSADOR_ORGANIZATION.md` instructions for obtaining the values for:
  - `githubID`
  - `slack`

Related to https://github.com/asyncapi/community/issues/1620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GitHub and Slack ID fields for ambassador members to enhance member profiles.

- **Documentation**
  - Updated instructions to guide ambassador candidates on how to obtain and provide their GitHub and Slack IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->