### PR TITLE
chore: add Daniel to TSC

### DIFF
--- a/AMBASSADORS_MEMBERS.json
+++ b/AMBASSADORS_MEMBERS.json
@@ -56,8 +56,9 @@
     "github": "danielkocot",
     "twitter": "dk_1977",
     "linkedin": "danielkocot",
-    "company": "Codecentric AG",
+    "company": "codecentric AG",
     "country": "🇩🇪",
+    "isTscMember": true,	  
     "contributions": [
       {
 	"type": "article",


### PR DESCRIPTION
Added key to become part of the TSC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the company name formatting for Daniel Kocot in the ambassadors list.
	- Added a new indicator showing Daniel Kocot as a TSC member.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->