### PR TITLE
chore: migrate from sendgrid to mailjet

### DIFF
--- a/.github/workflows/vote-notify.yml
+++ b/.github/workflows/vote-notify.yml
@@ -74,14 +74,15 @@ jobs:
 
       # Needed as axios and js-yaml are not available in the default environment
       - name: Install the dependencies
-        run: npm install js-yaml@4.1.0 axios@1.7.4 @sendgrid/mail@8.1.4
+        run: npm install js-yaml@4.1.0 axios@1.7.4 node-mailjet@6.0.8
         shell: bash
 
       - name: Notify TSC Members
         uses: actions/github-script@v7
         id: notify
         env:
-          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          MAILJET_API_KEY: ${{ secrets.MAILJET_PUBLIC_KEY}}
+          MAILJET_API_SECRET: ${{ secrets.MAILJET_PRIVATE_KEY }}
           # default to 'both' if inputs.notification_method is undefined (schedule runs)
           NOTIFY_METHOD: ${{ github.event.inputs.notification_method || 'both' }}
           SLACK_DM: ${{ secrets.SLACK_DM_TSC }}

--- a/.github/workflows/vote-notify.yml
+++ b/.github/workflows/vote-notify.yml
@@ -74,7 +74,7 @@ jobs:
 
       # Needed as axios and js-yaml are not available in the default environment
       - name: Install the dependencies
-        run: npm install js-yaml@4.1.0 axios@1.7.4 node-mailjet@6.0.8
+        run: npm install js-yaml@4.1.0 axios@1.7.4 node-mailjet@6.0.9
         shell: bash
 
       - name: Notify TSC Members


### PR DESCRIPTION
**Description**

Sadly, due to sendgrid stopping its free plans we have to migrate to another mailing service.
<img width="1016" height="930" alt="image" src="https://github.com/user-attachments/assets/5c64c241-290c-4771-bff1-b077030e9064" />

Proof of working: https://github.com/ash17290/asyncapi-community/actions/runs/16524890677/job/46735556645

**TO-DO**
@derberg you would have to create an account in [mailjet](https://app.mailjet.com/signup?lang=en_US). And verify the asyncapi mail and get the public and secret keys from API management. These need to be stored in `MAILJET_PUBLIC_KEY` and `MAILJET_PRIVATE_KEY` secret respectively.

The older sendgrid one can be removed.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Switched email delivery service from SendGrid to Mailjet for all notification emails.
  * Updated environment variables and dependencies to support Mailjet integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->