### PR TITLE
docs: add holopin badges section

### DIFF
--- a/docs/080-holopin-badges/_section.md
+++ b/docs/080-holopin-badges/_section.md
@@ -1,0 +1,3 @@
+---
+title: Holopin Badges
+---

--- a/docs/080-holopin-badges/index.md
+++ b/docs/080-holopin-badges/index.md
@@ -1,0 +1,29 @@
+---
+title: Holopin Badges for Maintainers
+weight: 80
+---
+
+# Holopin Badges for Maintainers
+
+Holopin is a platform that allows open source maintainers to issue digital badges to contributors, recognizing their efforts in a fun and verifiable way.  
+This guide explains how AsyncAPI maintainers can set up Holopin for their repositories, prerequisites to follow, and how to use the Holopin bot.
+
+## Prerequisites
+- Admin or maintainer access to the GitHub repository.  
+- A Holopin account: [https://holopin.io](https://holopin.io)  
+- The Holopin GitHub App installed: [Holopin GitHub Integration](https://docs.holopin.io/integrations/github)  
+
+## Setup Holopin for your repo
+1. Create a file named `.github/holopin.yml` in your repository.  
+2. Copy the configuration from [AsyncAPI’s holopin.yml example](https://github.com/asyncapi/.github/blob/master/.github/holopin.yml).  
+3. Update the badge definitions and rules as needed.  
+
+## Using the Holopin bot
+- The Holopin bot automatically issues badges based on rules in `holopin.yml`.  
+- You can also issue badges manually through the Holopin dashboard.  
+- More details: [Holopin GitHub Integration Guide](https://docs.holopin.io/integrations/github)  
+
+## Need help?
+- Check the [Holopin docs](https://docs.holopin.io)  
+- Contact [support@holopin.io](mailto:support@holopin.io)  
+- Or ask in the [AsyncAPI Slack](https://www.asyncapi.com/slack)  


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**



- Added a new documentation section: `080-holopin-badges`
- Created `_section.md` and `index.md` files with details on how maintainers can:
  - Set up the Holopin badge workflow for their repos
  - Understand prerequisites (e.g., following the [AsyncAPI Onboarding Guide](https://www.asyncapi.com/docs/community/000-onboarding))
  - Use the Holopin bot to issue badges, find badge links, and who to contact
- Updated community docs navigation to include Holopin Badges



fixes #2041


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Holopin Badges” section with proper page metadata.
  * Introduced a new guide for maintainers: explains prerequisites (access and accounts), setup via repository configuration, customizing badge definitions and rules, and how automated issuance works with the bot.
  * Includes steps for manual badge issuance via the dashboard.
  * Provides links to help resources, including official docs, support contact, and community channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->