### PR TITLE
chore: add @Adi-204 to TSC as maintainer of generator

### DIFF
--- a/MAINTAINERS.yaml
+++ b/MAINTAINERS.yaml
@@ -755,7 +755,10 @@
 - name: Adi Boghawala
   github: Adi-204
   twitter: AdiBoghawala
-  isTscMember: false
+  linkedin: adi-boghawala
+  slack: U0867GV384D
+  availableForHire: true
+  isTscMember: true
   repos:
     - generator
   githubID: 114283933


### PR DESCRIPTION
**Description**
Add @Adi-204 to TSC as maintainer of generator after merge of https://github.com/asyncapi/generator/pull/1685



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated maintainer profile details and availability information.
* **Chores**
  * Added maintainer contact and social links.
  * Updated maintainer team membership status.

No user-facing changes or functionality impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->