### PR TITLE
docs(bounty): clarify that Bounty Program is mutex-like

### DIFF
--- a/docs/010-contribution-guidelines/BOUNTY_PROGRAM.md
+++ b/docs/010-contribution-guidelines/BOUNTY_PROGRAM.md
@@ -189,6 +189,8 @@ A dropped Bounty Issue can not be assigned again to the same Bounty Program Part
 
 ## Additional Conditions
 
+The Bounty Program operates on a mutual-exclusion basis: during the time of participation of a GitHub issue in the Bounty Program, contributions (code, documentation, design, and other solutions) are accepted only from the assigned Bounty Program Participants.
+
 AsyncAPI Maintainers are allowed to work on Bounty Issues submitted by themselves.
 
 Bounty Program Participant is allowed to choose up to two Bounty Issues of any Complexity Level for simultaneous resolution.


### PR DESCRIPTION
This PR clarifies, by stating explicitly, that the Bounty Program operates on a mutual-exclusion basis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated Contribution Guidelines to clarify the Bounty Program’s mutual-exclusion policy: while an issue is enrolled, only contributions from assigned Bounty Program participants are accepted.
  * Reinforced this rule across the document to improve visibility.
  * Enhances clarity for contributors, reduces conflicts on active bounty issues, and streamlines review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->