### PR TITLE
docs(bounty): clarify Maintainers from other repos may work but need pre-approval

### DIFF
--- a/docs/010-contribution-guidelines/BOUNTY_PROGRAM.md
+++ b/docs/010-contribution-guidelines/BOUNTY_PROGRAM.md
@@ -35,7 +35,7 @@ The approximate maximum quantity of Bounty Issues per calendar quarter round var
 
 Bounty Program Participants are prioritized in the following order:
 
-1. AsyncAPI Maintainers (from the Bounty Issue's repository), checked at [MAINTAINERS.yaml](../../MAINTAINERS.yaml)
+1. AsyncAPI Maintainers (from the Bounty Issue's repository or from other AsyncAPI repositories who have a prior agreement with the Bounty Issue repository's Maintainers to work on the Bounty Issue), checked at [MAINTAINERS.yaml](../../MAINTAINERS.yaml)
 
 2. Regular contributors (GitHub users who have three or more Pull Requests merged throughout the AsyncAPI GitHub Organization, checked with https://github.com/search?q=org%3Aasyncapi+is%3Apr+is%3Amerged+author%3Agh_username).
 


### PR DESCRIPTION
This PR clarifies that AsyncAPI Maintainers who are not listed in the Bounty Issue repository's `CODEOWNERS` file may also work on a Bounty Issue opened in that repository, provided they have obtained prior agreement from the Bounty Issue repository's Maintainers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Bounty Program guidelines to clarify prioritization: top-priority Maintainers now include AsyncAPI Maintainers from other repositories with prior agreement.
  * Corrected numbering of the top-priority item from -1 to 1 for consistency.
  * No other prioritization items or references were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->