### PR TITLE
docs(bounty): remove 'mentoring' from desc of Bounty Program in another file

### DIFF
--- a/docs/020-governance-and-policies/PROJECT_FUNDING.md
+++ b/docs/020-governance-and-policies/PROJECT_FUNDING.md
@@ -74,9 +74,9 @@ To meet the demands of our growing community, we require full-time commitment. W
 
 We aim to establish our own swag store to efficiently distribute merchandise to contributors, mentees, ambassadors, and other community members. Part of the proceeds from the store can help cover the cost of complimentary swag.
 
-#### Bounty program
+#### Bounty Program
 
-Our bounty program seeks to recognize and reward dedicated contributors and maintainers without relying solely on company-sponsored employees or volunteers. We provide newcomers with free mentoring and assistance in building their contributor portfolios, making it easier for them to secure rewarding tech jobs.
+Our Bounty Program seeks to recognize and reward dedicated contributors and maintainers without relying solely on company-sponsored employees or volunteers. It also provides newcomers with the opportunity to build their contributor portfolios, making it easier for them to secure rewarding tech jobs.
 
 #### Services
 


### PR DESCRIPTION
This PR removes the word 'mentoring' from the description of the Bounty Program and slightly rewrites it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized heading capitalization in the Bounty Program section.
  * Refined language to a neutral voice, emphasizing opportunities for newcomers to build contributor portfolios.
  * Improved clarity, readability, and consistency across governance and policies content.
  * Updated phrasing to better reflect program scope without internal role references.
  * No functional impact to product behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->