### PR TITLE
docs: missing closing quote in image alt attribute

### DIFF
--- a/docs/060-meetings-and-communication/MEETINGS_ORGANIZATION.md
+++ b/docs/060-meetings-and-communication/MEETINGS_ORGANIZATION.md
@@ -128,7 +128,7 @@ This is what you need to do to kick it off:
 
 1. Make sure you do not create a new event, but select the one you already created on YouTube, with closed captions on:
 
-    <img src="../../assets/meetings/restream7.png" width="40%" alt="Restream: Create event />
+    <img src="../../assets/meetings/restream7.png" width="40%" alt="Restream: Create event" />
 
 1. You are ready to `Go Live`
 


### PR DESCRIPTION
**Description**

Fixed missing closing quote that fails website build for documentation

**Related issue(s)**
Related to #2035
See also https://github.com/asyncapi/website/pull/4404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected HTML syntax in the Meeting Organization documentation, fixing an incomplete alt attribute for an image in the Restream-first section.
  * The alt text is now properly quoted and the tag closed, improving accessibility and preventing potential rendering issues in some viewers.
  * No content changes; this is a formatting fix only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->