### PR TITLE
ci: tighten security of github actions

### DIFF
--- a/.github/actions/verifyTSCMember/action.yml
+++ b/.github/actions/verifyTSCMember/action.yml
@@ -1,4 +1,5 @@
 name: Verify Member
+description: 'Action to verify whether the person is TSC Member or not'
 outputs:
   isTSCMember:
     description: 'Check whether the person is TSCMember or not'
@@ -21,11 +22,13 @@ runs:
     - name: Verify TSC Member
       id: verify_member
       uses: actions/github-script@v6
+      env:
+        COMMENTER_NAME: ${{ inputs.authorName }}
       with:
         script: |
           const yaml = require('js-yaml');
           const fs = require('fs');
-          const commenterName = '${{ inputs.authorName }}';
+          const commenterName = process.env.COMMENTER_NAME;
           let isTSCMember = false;
           try {
             // Load YAML file

--- a/.github/workflows/cancel-event.yml
+++ b/.github/workflows/cancel-event.yml
@@ -27,7 +27,10 @@ jobs:
         working-directory: ./.github/workflows/create-event-helpers
       - name: Remove Google Calendar entry
         uses: actions/github-script@v4
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_CLOSED_AT: ${{ github.event.issue.closed_at }}
         with:
           script: |
             const { deleteEvent } = require('./.github/workflows/create-event-helpers/calendar/index.js');
-            deleteEvent('${{ github.event.issue.number }}', '${{ github.event.issue.closed_at }}');
+            deleteEvent(process.env.ISSUE_NUMBER, process.env.ISSUE_CLOSED_AT);

--- a/.github/workflows/create-event-workflow-reusable.yml
+++ b/.github/workflows/create-event-workflow-reusable.yml
@@ -121,7 +121,7 @@ jobs:
             const setupZoom = require('./.github/workflows/create-event-helpers/zoom/index.js');
             setupZoom('${{ inputs.date }}', '${{ inputs.time }}', '${{ inputs.host }}', '${{ inputs.alternative_host }}');
       - name: Create issue with meeting details
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # version v2 https://github.com/JasonEtco/create-an-issue/tree/v2/
         id: create-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -148,7 +148,7 @@ jobs:
             const { addEvent } = require('./.github/workflows/create-event-helpers/calendar/index.js');
             addEvent('${{ steps.zoom.outputs.meetingUrl }}', '${{ inputs.date }}', '${{ inputs.time }}', '${{ steps.create-issue.outputs.number }}');
       - name: Publish information about meeting to Twitter
-        uses: m1ner79/Github-Twittction@v1.0.1
+        uses: m1ner79/Github-Twittction@6269f2c6ace92b904304ca33a18aebd5e5ae9ee7 # version v1.0.1 https://github.com/m1ner79/Github-Twittction/tree/v1.0.1/
         with:
           twitter_status: "New meeting scheduled 💪\n\nName: ${{ inputs.meeting_name }}\n\nCheck what is it about and how to connect 👇🏼 https://github.com/asyncapi/community/issues/${{ steps.create-issue.outputs.number }}"
           twitter_consumer_key: ${{ secrets.TWITTER_CONSUMER_KEY }}

--- a/.github/workflows/vote-verifcation.yml
+++ b/.github/workflows/vote-verifcation.yml
@@ -19,46 +19,53 @@ jobs:
       - name: Checking the person authenticity.
         if: (github.event.comment.body == '/vote') || (github.event.comment.body == '/cancel-vote')
         uses: actions/github-script@v6
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          ACTOR: ${{ github.actor }}
         with:
           github-token: ${{ secrets.GH_TOKEN_BOT_EVE }}
           script : |
                const isTSCMember = ${{ steps.verify_member.outputs.isTSCMember}}
                   if(!isTSCMember) {
-                   const commentText = `Hi @${{ github.actor }}, since you are not a [TSC Member](https://www.asyncapi.com/community/tsc), you cannot start or stop voting. Please [read more about voting process](https://github.com/asyncapi/community/blob/master/voting.md)`;
-                   console.log(`User ❌ @${{ github.actor }} is not a TSC Member`);
+                   const commentText = `Hi @${process.env.ACTOR}, since you are not a [TSC Member](https://www.asyncapi.com/community/tsc), you cannot start or stop voting. Please [read more about voting process](https://github.com/asyncapi/community/blob/master/voting.md)`;
+                   console.log(`User ❌ @${process.env.ACTOR} is not a TSC Member`);
                    github.rest.issues.createComment({
                      issue_number: context.issue.number,
                      owner: context.repo.owner,
                      repo: context.repo.repo,
                     body: commentText
                   });
-               } else if('${{github.actor}}' != 'git-vote[bot]') {
-                 console.log(`User ✅ @${{ github.actor }} is a TSC Member`);
+               } else if(process.env.ACTOR != 'git-vote[bot]') {
+                 console.log(`User ✅ @${process.env.ACTOR} is a TSC Member`);
                } 
 
       - name: Add the label
         run: |
          if [ "${{steps.verify_member.outputs.isTSCMember}}" == "true" ]; then
-          if [ "${{ github.event.comment.body }}" == "/vote" ]; then
+          if [ "$COMMENT_BODY" == "/vote" ]; then
             if [ "${{ github.event_name }}" != "pull_request" ]; then
-              gh issue edit ${{ github.event.issue.number }} --add-label "vote"
+              gh issue edit "$ISSUE_NUMBER" --add-label "vote"
             else
-              gh pr edit ${{ github.event.issue.number }} --add-label "vote"
+              gh pr edit "$ISSUE_NUMBER" --add-label "vote"
             fi
           fi
          fi
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_BOT_EVE }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
       - name: Remove the label
         run: |
          if [ "${{steps.verify_member.outputs.isTSCMember}}" == "true" ]; then
-          if [ "${{ github.event.comment.body }}" == "/cancel-vote" ]; then
+          if [ "$COMMENT_BODY" == "/cancel-vote" ]; then
             if [ "${{ github.event_name }}" != "pull_request" ]; then
-              gh issue edit ${{ github.event.issue.number }} --remove-label "vote"
+              gh issue edit "$ISSUE_NUMBER" --remove-label "vote"
             else
-              gh pr edit ${{ github.event.issue.number }} --remove-label "vote"
+              gh pr edit "$ISSUE_NUMBER" --remove-label "vote"
             fi
           fi
          fi
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_BOT_EVE }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
**Description**

This pull request updates several GitHub Actions workflows to improve maintainability, security, and consistency by standardizing how environment variables are passed and referenced, and by pinning action versions to specific commits. The changes primarily affect automated processes for verifying TSC membership, handling event creation and cancellation, and voting workflows.

**Environment variable handling and workflow consistency:**

* Updated multiple workflows (`.github/actions/verifyTSCMember/action.yml`, `.github/workflows/cancel-event.yml`, `.github/workflows/vote-verifcation.yml`) to use environment variables instead of string interpolation for passing data to scripts, improving reliability and clarity. [[1]](diffhunk://#diff-143cc555ba7be8515ffac35135b493be794907a67c0afd0e1f838509486673a4R25-R31) [[2]](diffhunk://#diff-cb89f8d09f36fb15efa8e25e91be522e1c12d923dff6c1019662a45c1d0aa853R30-R36) [[3]](diffhunk://#diff-6d27f6d81f75a14483e7317a6d35826bc6a1f9d22a55b3f86921d3a157bde8a9R22-R71)
* Standardized shell script usage in voting workflows to reference environment variables (e.g., `COMMENT_BODY`, `ISSUE_NUMBER`) for label management, ensuring consistent and error-free variable access.

**Security and maintainability improvements:**

* Pinned GitHub Actions (`JasonEtco/create-an-issue`, `m1ner79/Github-Twittction`) to specific commit SHAs in `.github/workflows/create-event-workflow-reusable.yml`, reducing the risk of unexpected changes from upstream updates. [[1]](diffhunk://#diff-4ac0122dc1e5a7dce923ef68bd9c172cdf214773f11f569ef6a40046945eec88L124-R124) [[2]](diffhunk://#diff-4ac0122dc1e5a7dce923ef68bd9c172cdf214773f11f569ef6a40046945eec88L151-R151)

**Documentation updates:**

* Added a description field to `.github/actions/verifyTSCMember/action.yml` to clarify the purpose of the action for future maintainers.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a clear description and required commenter name input to the member verification action; exposes a membership result output.
  * Updated workflows to use environment variables for actor, comment body, issue number, and closed timestamp, improving consistency and logs without changing behavior.
  * Pinned third-party actions to specific commit SHAs for reproducible and predictable CI runs.
* **Refactor**
  * Shifted scripts to read values from environment variables instead of inline context expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->