### PR TITLE
fix: update broken documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Our community is steered by a transparent governance board. You can learn more a
 The TSC is a group of maintainers and Ambassadors responsible for the maintenance and decision-making of the AsyncAPI Initiative. It was formed to ensure open governance and neutrality.
 
 ### Want To Become a TSC Member?
-- Read the requirements and responsibilities on becoming a [TSC Member](./TSC_MEMBERSHIP.md) or watch our [YouTube video on how to become a TSC member](https://www.youtube.com/watch?v=uG_aLF9Z1F0). 
-- Or explore if you meet the requirements of becoming an [AsyncAPI Ambassador](./AMBASSADOR_ORGANIZATION.md).
+- Read the requirements and responsibilities on becoming a [TSC Member](./docs/020-governance-and-policies/TSC_MEMBERSHIP.md) or watch our [YouTube video on how to become a TSC member](https://www.youtube.com/watch?v=uG_aLF9Z1F0). 
+- Or explore if you meet the requirements of becoming an [AsyncAPI Ambassador](./docs/020-governance-and-policies/AMBASSADOR_PROGRAM.md).
 
 ## Need Help? 🤝
 


### PR DESCRIPTION
### Summary
Fix broken documentation links in `README.md` that returned 404s.

### What changed
- TSC Membership link:
  - from: `./TSC_MEMBERSHIP.md`
  - to: `./docs/020-governance-and-policies/TSC_MEMBERSHIP.md`
- Ambassador Program link:
  - from: `./AMBASSADOR_ORGANIZATION.md`
  - to: `./docs/020-governance-and-policies/AMBASSADOR_PROGRAM.md`

### Why
- The referenced files live under `docs/020-governance-and-policies/`, so the old links produced 404 errors.
- This improves onboarding and reduces confusion when navigating governance docs.

### How to verify
1. Open the README in the branch.
2. Click both updated links and confirm they render the Markdown pages correctly in GitHub.

### Related
- (optional) Closes #<issue-number> if an issue exists.

### Checklist
- [x] Links resolve to existing files
- [x] Only README updated
- [x] No content changes beyond link targets