### PR TITLE
ci: improve docs link in docs preview automated build

### DIFF
--- a/.github/workflows/manual-netlify-preview.yml
+++ b/.github/workflows/manual-netlify-preview.yml
@@ -71,4 +71,4 @@ jobs:
           github-token: ${{ secrets.GH_TOKEN }}
           message: |
             🚀 **Docs preview deployed**
-            → ${{ steps.deploy.outputs.url }}
+            → ${{ steps.deploy.outputs.url }}/docs/community


### PR DESCRIPTION
small improvement so the link posted by bot, that points to preview of asyncapi website, out of the box points to community docs section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment preview configuration for pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->