### PR TITLE
fix: zoom scheduling was broken due to new API

### DIFF
--- a/.github/workflows/create-event-helpers/zoom/index.js
+++ b/.github/workflows/create-event-helpers/zoom/index.js
@@ -22,7 +22,7 @@ module.exports = async(date, time, host, cohost) => {
             method: 'POST',
             body: params,
             headers: {
-                Authorization: `Basic ${ process.env.ZOOM_TOKEN }`
+                Authorization: `Basic ${process.env.ZOOM_CLIENT_ID}:${ process.env.ZOOM_TOKEN }`
             },
         });
         token = (await tokenCreationResponse.json()).access_token;
@@ -52,9 +52,8 @@ module.exports = async(date, time, host, cohost) => {
         method: 'POST',
 
         headers: {
-            'User-Agent': 'Zoom-api-Jwt-Request',
-            'content-type': 'application/json',
-            Authorization: `bearer ${ token }`
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${ token }`
         },
 
         body: zoomSettings


### PR DESCRIPTION
It is impossible to schedule meetings using GitHub Actions. This should fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication headers for Zoom API integration, standardizing the authorization format and header structure for API requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->