### PR TITLE
fix: github actions to use Zoom client_id

### DIFF
--- a/.github/workflows/create-event-ad-hoc.yml
+++ b/.github/workflows/create-event-ad-hoc.yml
@@ -37,6 +37,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       ZOOM_ACCOUNT_ID: ${{ secrets.ZOOM_ACCOUNT_ID }}
       ZOOM_TOKEN: ${{ secrets.ZOOM_TOKEN }}
+      ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
       STREAM_URL: ${{ secrets.STREAM_URL }}
       STREAM_KEY: ${{ secrets.STREAM_KEY }}
       CALENDAR_ID: ${{ secrets.CALENDAR_ID }}

--- a/.github/workflows/create-event-community-meeting.yml
+++ b/.github/workflows/create-event-community-meeting.yml
@@ -30,6 +30,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       ZOOM_ACCOUNT_ID: ${{ secrets.ZOOM_ACCOUNT_ID }}
       ZOOM_TOKEN: ${{ secrets.ZOOM_TOKEN }}
+      ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
       STREAM_URL: ${{ secrets.STREAM_URL }}
       STREAM_KEY: ${{ secrets.STREAM_KEY }}
       CALENDAR_ID: ${{ secrets.CALENDAR_ID }}

--- a/.github/workflows/create-event-lets-talk-about.yml
+++ b/.github/workflows/create-event-lets-talk-about.yml
@@ -34,6 +34,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       ZOOM_ACCOUNT_ID: ${{ secrets.ZOOM_ACCOUNT_ID }}
       ZOOM_TOKEN: ${{ secrets.ZOOM_TOKEN }}
+      ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
       STREAM_URL: ${{ secrets.STREAM_URL }}
       STREAM_KEY: ${{ secrets.STREAM_KEY }}
       CALENDAR_ID: ${{ secrets.CALENDAR_ID }}

--- a/.github/workflows/create-event-spec-3-0.yml
+++ b/.github/workflows/create-event-spec-3-0.yml
@@ -31,6 +31,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       ZOOM_ACCOUNT_ID: ${{ secrets.ZOOM_ACCOUNT_ID }}
       ZOOM_TOKEN: ${{ secrets.ZOOM_TOKEN }}
+      ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
       STREAM_URL: ${{ secrets.STREAM_URL }}
       STREAM_KEY: ${{ secrets.STREAM_KEY }}
       CALENDAR_ID: ${{ secrets.CALENDAR_ID }}

--- a/.github/workflows/create-event-spec-3-docs.yml
+++ b/.github/workflows/create-event-spec-3-docs.yml
@@ -31,6 +31,7 @@ jobs:
       ZOOM_ACCOUNT_ID: ${{ secrets.ZOOM_ACCOUNT_ID }}
       ZOOM_TOKEN: ${{ secrets.ZOOM_TOKEN }}
       STREAM_URL: ${{ secrets.STREAM_URL }}
+      ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
       STREAM_KEY: ${{ secrets.STREAM_KEY }}
       CALENDAR_ID: ${{ secrets.CALENDAR_ID }}
       CALENDAR_SERVICE_ACCOUNT: ${{ secrets.CALENDAR_SERVICE_ACCOUNT }}

--- a/.github/workflows/create-event-thinking-out-loud.yml
+++ b/.github/workflows/create-event-thinking-out-loud.yml
@@ -36,6 +36,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       ZOOM_ACCOUNT_ID: ${{ secrets.ZOOM_ACCOUNT_ID }}
       ZOOM_TOKEN: ${{ secrets.ZOOM_TOKEN }}
+      ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
       STREAM_URL: ${{ secrets.STREAM_URL }}
       STREAM_KEY: ${{ secrets.STREAM_KEY }}
       CALENDAR_ID: ${{ secrets.CALENDAR_ID }}

--- a/.github/workflows/create-event-workflow-reusable.yml
+++ b/.github/workflows/create-event-workflow-reusable.yml
@@ -76,6 +76,7 @@ jobs:
     env:
       ZOOM_ACCOUNT_ID: ${{ secrets.ZOOM_ACCOUNT_ID }}
       ZOOM_TOKEN: ${{ secrets.ZOOM_TOKEN }}
+      ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
       STREAM_URL: ${{ secrets.STREAM_URL }}
       STREAM_KEY: ${{ secrets.STREAM_KEY }}
       CALENDAR_ID: ${{ secrets.CALENDAR_ID }}


### PR DESCRIPTION
Previous PR didn't solve the problem. Trying again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated event creation workflow configurations to include Zoom client ID support across multiple event types: ad-hoc events, community meetings, specification discussions, and thinking out loud sessions. The Zoom client ID is now available to all event creation automation pipelines for enhanced integration capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->