### PR TITLE
docs: fix broken link to contribution guidelines in onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Find all the resources you need to start contributing to our organization.
 
 1. Follow the [Code of Conduct](CODE_OF_CONDUCT.md) and help keep the community inclusive and respectful.
 
-2. Read the [Contribution Guide](docs/010-contribution-guidelines/contribution-flow.md) and learn how to contribute effectively.
+2. Read the [Contribution Guide](docs/community/
+010-contribution-guidelines/contribution-flow.md) and learn how to contribute effectively.
 
 3. Explore the [Community Contribution Onboarding Docs](docs/000-onboarding/docs-onboarding-checklist.md), a step-by-step guide for new contributors.
 

--- a/docs/000-onboarding/docs-onboarding-checklist.md
+++ b/docs/000-onboarding/docs-onboarding-checklist.md
@@ -12,11 +12,14 @@ Complete in order the following onboarding tasks:
 - [ ] Read the [AsyncAPI Slack etiquette](../060-meetings-and-communication/slack-etiquette). 
 - [ ] Join [the AsyncAPI Slack workspace](https://asyncapi.com/slack-invite).
 - [ ] Add the AsyncAPI calendar found in [the AsyncAPI events page](https://www.asyncapi.com/community/events).
-- [ ] Read the list of [technical writer contributor responsibilities](../010-contribution-guidelines/technical-writer-contributor-responsibilities).
-- [ ] Read and familiarize yourself with the [prerequisite knowledge topics](../010-contribution-guidelines/prerequisite-knowledge).
+- [ ] Read the list of [technical writer contributor responsibilities](../community/
+010-contribution-guidelines/technical-writer-contributor-responsibilities).
+- [ ] Read and familiarize yourself with the [prerequisite knowledge topics](../community/
+010-contribution-guidelines/prerequisite-knowledge).
 - [ ] Familiarize yourself with the [AsyncAPI Style Guide](../011-styleguide).
 - [ ] Read all docs under the following content buckets: `Concepts`, `Tutorials`, `Reference`. (Take the time to go through each tutorial.)
-- [ ] Set up your local environment following our instructions for the [AsyncAPI git workflow](../010-contribution-guidelines/git-workflow).
+- [ ] Set up your local environment following our instructions for the [AsyncAPI git workflow](../community/
+010-contribution-guidelines/git-workflow).
 - [ ] Introduce yourself in AsyncAPI Slack in the `#01_introductions` channel and the `#13_docs` channel. Ask docs-related questions in #13_docs.
 - [ ] Request a good first docs issue in the [`#13_docs` Slack channel](https://asyncapi.com/slack-invite).
 - [ ] Attend [OPEN docs meetings](https://www.asyncapi.com/community/events) to chat with other maintainers, ask docs questions, and request help on docs blockers. 

--- a/docs/000-onboarding/index.md
+++ b/docs/000-onboarding/index.md
@@ -6,7 +6,8 @@ weight: 2
 
 The AsyncAPI technical writer onboarding guide teaches new community members how to contribute to our documentation effectively. 
 
-> For a comprehensive understanding of the various ways you can contribute to the AsyncAPI Initiative, please consult the [AsyncAPI contributing guidelines](../010-contribution-guidelines)
+> For a comprehensive understanding of the various ways you can contribute to the AsyncAPI Initiative, please consult the [AsyncAPI contributing guidelines](../community/
+010-contribution-guidelines)
 
 The goal is providing docs contributors with the necessary tools and knowledge to:
 

--- a/docs/000-onboarding/maintainer-guide.md
+++ b/docs/000-onboarding/maintainer-guide.md
@@ -46,7 +46,8 @@ Before you can become a **maintainer**, you need to start as a **contributor**. 
 
 ### 2. Open a PR
 
-For a comprehensive guide on how to create a fork and start contributing, refer to the [AsyncAPI Git Workflow Guide](../010-contribution-guidelines/git-workflow).
+For a comprehensive guide on how to create a fork and start contributing, refer to the [AsyncAPI Git Workflow Guide](../community/
+010-contribution-guidelines/git-workflow).
 
 - **Fork the repository**: Fork the repository you want to contribute to and create a new branch for your changes.
 

--- a/docs/010-contribution-guidelines/Become-maintainer-in-existing-project.md
+++ b/docs/010-contribution-guidelines/Become-maintainer-in-existing-project.md
@@ -28,7 +28,8 @@ To open a pull request successfully, follow our [Git workflows contributors guid
 Use the following steps to open your pull request:
 1. Configure a fork
 2. Work on it locally 
-3. Write an appropriate PR title using the [conventional commits specification](../010-contribution-guidelines/conventional-commits)
+3. Write an appropriate PR title using the [conventional commits specification](../community/
+010-contribution-guidelines/conventional-commits)
 4. Test your PR against GitHub checks to ensure they all pass
 
 **Step 3: Get Pull Request Merged**

--- a/docs/010-contribution-guidelines/code-contributor-guide.md
+++ b/docs/010-contribution-guidelines/code-contributor-guide.md
@@ -26,7 +26,8 @@ Welcome to the AsyncAPI community! We're excited to have you here. Think of Asyn
 
 ## Submit Your First Pull Request (PR)  
 
-Once you've made and committed your changes (following the Git Workflow guide), you need to create a Pull Request (PR) to propose merging your work into the official AsyncAPI repository. Make sure to use the [conventional commit style](../010-contribution-guidelines/conventional-commits) while creating PRs and follow these steps:  
+Once you've made and committed your changes (following the Git Workflow guide), you need to create a Pull Request (PR) to propose merging your work into the official AsyncAPI repository. Make sure to use the [conventional commit style](../community/
+010-contribution-guidelines/conventional-commits) while creating PRs and follow these steps:  
 
 ### Create a Pull Request (PR)
 

--- a/docs/010-contribution-guidelines/git-workflow.md
+++ b/docs/010-contribution-guidelines/git-workflow.md
@@ -118,7 +118,8 @@ You can follow the steps from the [GitHub documentation](https://docs.github.com
 ## Start Contributing
 
 1. Create a branch on your fork.
-2. Commit changes with clear messages. Use the [Conventional Commits](../010-contribution-guidelines/conventional-commits) format.
+2. Commit changes with clear messages. Use the [Conventional Commits](../community/
+010-contribution-guidelines/conventional-commits) format.
 3. Push changes to your fork:
 
     ```bash

--- a/docs/010-contribution-guidelines/open-docs-pull-request.md
+++ b/docs/010-contribution-guidelines/open-docs-pull-request.md
@@ -8,7 +8,8 @@ Create and submit a docs pull request (PR) via the following steps:
 
 - A Docs’ PR should solve one documentation problem. 
 - If there is no current issue for the docs task you want to accomplish, please open a docs issue before creating a PR. 
-- Use the [conventional commit style](../010-contribution-guidelines/conventional-commits) when creating PRs. Always create a docs issue or PR with the `docs:` prefix in the title. 
+- Use the [conventional commit style](../community/
+010-contribution-guidelines/conventional-commits) when creating PRs. Always create a docs issue or PR with the `docs:` prefix in the title. 
 - Please check your contribution and ensure it follows the AsyncAPI style guide.
 - Tag other technical writers to review your document. 
 - Tag an engineer or subject matter expert (SME) to review the technical details.

--- a/docs/011-styleguide/styling.md
+++ b/docs/011-styleguide/styling.md
@@ -132,9 +132,11 @@ Use asterisks for italics (`*italic*`) and bold (`**bold**`). You can also use u
 ### Links
 Use square brackets to describe links and a parenthesis to insert the actual links. Always use descriptive link text. Avoid phrases like "click here."
 
-- **✅ Good:** See our [Contribution Guide](../010-contribution-guidelines) for more.
+- **✅ Good:** See our [Contribution Guide](../community/
+010-contribution-guidelines) for more.
 
-- **❌ Bad:** For more info, [click here](../010-contribution-guidelines).
+- **❌ Bad:** For more info, [click here](../community/
+010-contribution-guidelines).
 
 ### Code Blocks
 Use backticks for inline code (`const foo = 'bar';`). For code blocks, use triple backticks and specify the language for syntax highlighting.

--- a/docs/011-styleguide/version-control.md
+++ b/docs/011-styleguide/version-control.md
@@ -95,4 +95,5 @@ When contributing to documentation, keep the following in mind:
 
 ### Need Help?
 
-Need more assistance with contributing to documentation, check out the [AsyncAPI contribution flow guidelines](../010-contribution-guidelines/contribution-flow).
+Need more assistance with contributing to documentation, check out the [AsyncAPI contribution flow guidelines](../community/
+010-contribution-guidelines/contribution-flow).

--- a/docs/020-governance-and-policies/TSC_MEMBERSHIP.md
+++ b/docs/020-governance-and-policies/TSC_MEMBERSHIP.md
@@ -98,7 +98,8 @@ To become a TSC member, you must be a project maintainer within the AsyncAPI Ini
 You can become a maintainer by either:
 1. Initiating a new repository or project and becoming its maintainer.
 2. Donating to an existing repository or project and continuing to maintain it.
-3. Supporting and committing to existing projects and being invited by other maintainers to join them as a maintainer. For more information, refer to [Become a maintainer in an existing project](../010-contribution-guidelines/Become-maintainer-in-existing-project).
+3. Supporting and committing to existing projects and being invited by other maintainers to join them as a maintainer. For more information, refer to [Become a maintainer in an existing project](../community/
+010-contribution-guidelines/Become-maintainer-in-existing-project).
 
 There's no invitation flow to join the TSC; it's something that you are allowed to do as a maintainer by default, as described in the [charter signed with the Linux Foundation when AsyncAPI joined the foundation](CHARTER). Instead, there is an automation flow in place that adds a new maintainer to the [`community/MAINTAINERS.yaml`](https://github.com/asyncapi/community/blob/master/MAINTAINERS.yaml) list every time the [CODEOWNERS][code-owners] file is updated in any project. And the only thing you need to do is to find your name in the `MAINTAINERS.yaml` list and change `isTscMember` from `false` to `true` along with updating other missing information like, for example, your `slack` ID.
 


### PR DESCRIPTION
## Description
Fixes broken links in the Community Onboarding documentation that were pointing to incorrect paths.

Several references to `010-contribution-guidelines` were missing the `community/` segment, which caused 404 errors on the published site.

## Changes
- Updated relative links to include `community/` where required.
- Verified all onboarding references resolve correctly.

## Type of change
Documentation fix (broken links)

## Checklist
-  Verified links point to the correct documentation location
-  Ensured changes only affect documentation paths (no functional changes)
-  Confirmed consistency with existing URL structure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized contribution guidelines into a new community subdirectory structure.
  * Updated internal documentation links across onboarding guides, contribution workflows, style guides, and governance documents to reflect the new directory organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->