### PR TITLE
fix: update outdated packages in youtube-to-spotify workflow

### DIFF
--- a/.github/workflows/youtube-to-spotify-for-podcasters.yml
+++ b/.github/workflows/youtube-to-spotify-for-podcasters.yml
@@ -26,7 +26,7 @@ jobs:
           # Verify the content was written successfully
           cat episode.json
       - name: Upload Episode from YouTube To Spotify for Podcasters
-        uses: Schroedinger-Hat/youtube-to-spotify@v2.6.0 # updated from Schrodinger-Hat/youtube-to-anchorfm v2.4.0 to Schroedinger-Hat/youtube-to-spotify v2.6.0
+        uses: Schroedinger-Hat/youtube-to-spotify@97346df423b2c37e6334b5cae17dbbe14434d8a9 # v2.6.0
         env:
           SPOTIFY_EMAIL: ${{ secrets.ANCHOR_EMAIL }}
           SPOTIFY_PASSWORD: ${{ secrets.ANCHOR_PASSWORD }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Updated actions/checkout@v3 to @v4
- Updated Schrodinger-Hat/youtube-to-anchorfm@v2.4.0 to Schroedinger-Hat/youtube-to-spotify@v2.6.0
- Updated env vars from ANCHOR_EMAIL/PASSWORD to SPOTIFY_EMAIL/PASSWORD to reflect Spotify's rebranding of Anchor.fm

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes #2324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched CI workflow uploads from AnchorFM to Spotify for Podcasters.
  * Upgraded workflow steps to newer releases.
  * Updated CI secrets to use Spotify credentials (existing secret mappings preserved).
  * Added post-processing to enforce mono audio during upload.
  * No other user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->