### PR TITLE
fix: pin action SHAs and downgrade youtube-to-spotify to v2.5.0

### DIFF
--- a/.github/workflows/youtube-to-spotify-for-podcasters.yml
+++ b/.github/workflows/youtube-to-spotify-for-podcasters.yml
@@ -26,6 +26,7 @@ jobs:
           # Verify the content was written successfully
           cat episode.json
       - name: Upload Episode from YouTube To Spotify for Podcasters
+        # Pinned to v2.5.0 due to npm "Missing script: start" error in v2.6.0
         uses: Schroedinger-Hat/youtube-to-spotify@601d281daadd2c210649aed350520a58cfad35eb # v2.5.0
         env:
           SPOTIFY_EMAIL: ${{ secrets.ANCHOR_EMAIL }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Pinned actions/checkout to v4.2.2 commit SHA to address Node.js 20 deprecation warning
- Downgraded Schroedinger-Hat/youtube-to-spotify from v2.6.0 to v2.5.0 to fix npm error Missing script: "start"

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes #2324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned CI workflow action references to specific commit snapshots to improve build reproducibility and stability.
  * Added an inline note in the workflow explaining the chosen pinning approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->