### PR TITLE
docs: improve onboarding by combining "How to Contribute" and "Where to Contribute"

### DIFF
--- a/docs/000-onboarding/how-to-contribute.md
+++ b/docs/000-onboarding/how-to-contribute.md
@@ -1,8 +1,16 @@
 ---
-title: How to Contribute
-weight: 20
+title: Contributing Guide
+weight: 10
 ---
 
-🚧 This document is under construction.
+# Contributing Guide
 
+## How to Contribute
+
+🚧 This section is under construction.  
+Please be patient as we work on it. Thank you. 🫶
+
+## Where to Contribute
+
+🚧 This section is under construction.  
 Please be patient as we work on it. Thank you. 🫶

--- a/docs/000-onboarding/where-to-contribute.md
+++ b/docs/000-onboarding/where-to-contribute.md
@@ -1,5 +1,4 @@
 ---
----
 title: Where to Contribute
 weight: 20
 ---

--- a/docs/000-onboarding/where-to-contribute.md
+++ b/docs/000-onboarding/where-to-contribute.md
@@ -1,8 +1,7 @@
 ---
+---
 title: Where to Contribute
-weight: 10
+weight: 20
 ---
 
-🚧 This document is under construction.
-
-Please be patient as we work on it. Thank you. 🫶
+This content has been moved to the Contributing Guide.


### PR DESCRIPTION
Closes #3499

### What this PR does

This PR simplifies the onboarding experience by combining the “How to Contribute” and “Where to Contribute” pages into a single Contributing Guide.

It also replaces the old “Where to Contribute” page with a short note pointing users to the new combined guide, helping avoid duplication.

### Why this change

Right now, the onboarding content is split across multiple pages, which can be confusing for new contributors. It’s not always clear where to start or which page to follow.

By merging these sections, we create a single, clearer entry point for contributors.

### Result

- Reduced duplication  
- Simpler navigation  
- Better onboarding experience for new contributors  

This is my first contribution, so I’d really appreciate any feedback 🙂

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed the contribution page title to "Contributing Guide" for clarity.
  * Moved and consolidated contribution content into a single guide to simplify onboarding and navigation.
  * Adjusted documentation ordering so the guide appears earlier in the onboarding flow.
  * Minor formatting fixes to ensure consistent rendering (including final newline).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->