### PR TITLE
chore: harden Github Actions workflows

### DIFF
--- a/.github/actions/verifyTSCMember/action.yml
+++ b/.github/actions/verifyTSCMember/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install the dependencies
       run: npm install js-yaml@4.1.0

--- a/.github/actions/verifyTSCMember/action.yml
+++ b/.github/actions/verifyTSCMember/action.yml
@@ -21,7 +21,7 @@ runs:
 
     - name: Verify TSC Member
       id: verify_member
-      uses: actions/github-script@v6
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         COMMENTER_NAME: ${{ inputs.authorName }}
       with:

--- a/.github/workflows/add-good-first-issue-labels.yml
+++ b/.github/workflows/add-good-first-issue-labels.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write    # This is needed to add labels to issues.
     steps:
       - name: Add label
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/ambassador_management.yml
+++ b/.github/workflows/ambassador_management.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Compare files
         id: compare-files
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Invite new ambassadors to the organization
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
@@ -101,7 +101,7 @@ jobs:
             }
 
       - name: Add new ambassadors to the team
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Display welcome message for new ambassadors
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove ambassadors from the organization
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Display goodbye message to removed ambassadors
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
@@ -208,7 +208,7 @@ jobs:
         run: npm install js-yaml@4.1.0
 
       - name: Add Former Ambassador to Emeritus.yaml and print
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ambassador_management.yml
+++ b/.github/workflows/ambassador_management.yml
@@ -1,16 +1,20 @@
 name: Ambassador Management Workflow
 
-on:
-  pull_request_target:
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target: # Using pull_request_target since this workflow needs to run with write permissions to the repository to manage organization membership and teams
     types: [closed]
     paths:
       - 'AMBASSADORS_MEMBERS.yaml'
+
+permissions: {}  # at workflow level to deny all permissions by default
 
 jobs:
   detect_ambassador_changes:
     if: github.event.pull_request.merged
     name: Update Ambassadors Members
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # only needs to read permissions to compare the files
 
     steps:
       - name: Checkout base commit
@@ -18,12 +22,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: community-main
+          persist-credentials: false
 
       - name: Checkout head commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: community
+          persist-credentials: false
 
       - name: Install js-yaml
         run: npm install js-yaml@4.1.0
@@ -67,12 +73,16 @@ jobs:
             core.info(fs.realpathSync('./community/AMBASSADORS_MEMBERS.yaml'));
 
       - name: Debug newAmbassadors output
+        env:
+          NEW_AMBASSADORS: ${{ steps.compare-files.outputs.newAmbassadors }}
         run: |
-          echo "newAmbassadors = ${{ steps.compare-files.outputs.newAmbassadors }}"
+          echo "newAmbassadors = $NEW_AMBASSADORS"
 
       - name: Debug removedAmbassadors output
+        env:
+          REMOVED_AMBASSADORS: ${{ steps.compare-files.outputs.removedAmbassadors }}
         run: |
-          echo "removedAmbassadors = ${{ steps.compare-files.outputs.removedAmbassadors }}"
+          echo "removedAmbassadors = $REMOVED_AMBASSADORS"
 
     outputs:
       newAmbassadors: ${{ steps.compare-files.outputs.newAmbassadors }}
@@ -85,10 +95,12 @@ jobs:
     steps:
       - name: Invite new ambassadors to the organization
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          NEW_AMBASSADORS: ${{ needs.detect_ambassador_changes.outputs.newAmbassadors }}
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
-            const newAmbassadors = '${{ needs.detect_ambassador_changes.outputs.newAmbassadors }}'.split(',');
+            const newAmbassadors = process.env.NEW_AMBASSADORS.split(',');
             for (const ambassador of newAmbassadors) {
               try {
                 await github.request('PUT /orgs/{org}/memberships/{username}', {
@@ -102,10 +114,12 @@ jobs:
 
       - name: Add new ambassadors to the team
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          NEW_AMBASSADORS: ${{ needs.detect_ambassador_changes.outputs.newAmbassadors }}
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
-            const newAmbassadors = '${{ needs.detect_ambassador_changes.outputs.newAmbassadors }}'.split(',');
+            const newAmbassadors = process.env.NEW_AMBASSADORS.split(',');
             for (const ambassador of newAmbassadors) {
               try {
                 await github.request('PUT /orgs/{org}/teams/{team_slug}/memberships/{username}', {
@@ -125,13 +139,15 @@ jobs:
     needs: add_ambassador
     if: needs.add_ambassador.outputs.newAmbassadors != ''
     runs-on: ubuntu-latest
+    env:
+      NEW_AMBASSADORS: ${{ needs.add_ambassador.outputs.newAmbassadors }}
     steps:
       - name: Display welcome message for new ambassadors
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
-            const newAmbassadors = "${{ needs.add_ambassador.outputs.newAmbassadors }}".split(",");
+            const newAmbassadors = process.env.NEW_AMBASSADORS.split(",");
             console.log(`New ambassadors: ${newAmbassadors}`);
             const welcomeMessage = newAmbassadors.map((ambassador) => `@${ambassador.trim().replace(/^@/, '')} We invited you to join the AsyncAPI organization, and you are added to the team that lists all Ambassadors.\n
 
@@ -145,13 +161,15 @@ jobs:
     needs: detect_ambassador_changes
     if: needs.detect_ambassador_changes.outputs.removedAmbassadors != ''
     runs-on: ubuntu-latest
+    env:
+      REMOVED_AMBASSADORS: ${{ needs.detect_ambassador_changes.outputs.removedAmbassadors }}
     steps:
       - name: Remove ambassadors from the organization
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
-            const removedAmbassadors = '${{ needs.detect_ambassador_changes.outputs.removedAmbassadors }}'.split(',');
+            const removedAmbassadors = process.env.REMOVED_AMBASSADORS.split(',');
             for (const ambassador of removedAmbassadors) {
               try {
                 await github.request('DELETE /orgs/{org}/memberships/{username}', {
@@ -175,13 +193,15 @@ jobs:
     needs: remove_ambassador
     if: needs.remove_ambassador.outputs.removedAmbassadors != ''
     runs-on: ubuntu-latest
+    env:
+      REMOVED_AMBASSADORS: ${{ needs.detect_ambassador_changes.outputs.removedAmbassadors }}
     steps:
       - name: Display goodbye message to removed ambassadors
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
-              const removedAmbassadors = "${{ needs.remove_ambassador.outputs.removedAmbassadors }}".split(",");
+              const removedAmbassadors = process.env.REMOVED_AMBASSADORS.split(",");
 
               // Goodbye message to removed ambassadors
               const combinedMessages = removedAmbassadors.map((ambassador) => {
@@ -203,12 +223,16 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install js-yaml
         run: npm install js-yaml@4.1.0
 
       - name: Add Former Ambassador to Emeritus.yaml and print
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REMOVED_AMBASSADORS: ${{ needs.remove_ambassador.outputs.removedAmbassadors }}
         with:
           script: |
             const fs = require('fs');
@@ -221,8 +245,7 @@ jobs:
             const content = fs.readFileSync(path, 'utf8').trim(); // remove any trailing whitespaces
 
             // Parse the removedAmbassadors comma-separated string to an array
-            const removedAmbassadors = '${{ needs.remove_ambassador.outputs.removedAmbassadors }}'
-              .split(',')
+            const removedAmbassadors = process.env.REMOVED_AMBASSADORS.split(',')
               .map((ambassador) => ambassador.trim())
               .filter(Boolean);
 

--- a/.github/workflows/ambassador_management.yml
+++ b/.github/workflows/ambassador_management.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: Checkout base commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: community-main
 
       - name: Checkout head commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: community
@@ -202,7 +202,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install js-yaml
         run: npm install js-yaml@4.1.0
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Report workflow run status to Slack
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
         env:
           SLACK_WEBHOOK: ${{secrets.SLACK_CI_FAIL_NOTIFY}}
           SLACK_TITLE: '🚨 Ambassador Management Workflow failed 🚨'

--- a/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
+++ b/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add ready-to-merge label
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GITHUB_ACTOR: ${{ github.actor }}
         with:
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add do-not-merge label
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # Bot PAT so the `labeled` event can trigger downstream workflows.
           github-token: ${{ secrets.GH_TOKEN }}
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add autoupdate label
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # Bot PAT so the `labeled` event can trigger the autoupdate workflow.
           github-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/automerge-for-humans-merging.yml
+++ b/.github/workflows/automerge-for-humans-merging.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Get PR authors
         id: authors
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // Get paginated list of all commits in the PR
@@ -71,7 +71,7 @@ jobs:
 
       - name: Create commit message
         id: create-commit-message
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           AUTHORS_JSON: ${{ steps.authors.outputs.result }}
         with:

--- a/.github/workflows/automerge-for-humans-remove-ready-to-merge-label-on-edit.yml
+++ b/.github/workflows/automerge-for-humans-remove-ready-to-merge-label-on-edit.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write # required to remove labels and post comments on PR issues 
     steps:
       - name: Remove label
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/automerge-orphans.yml
+++ b/.github/workflows/automerge-orphans.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Get list of orphans
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: orphans
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/automerge-orphans.yml
+++ b/.github/workflows/automerge-orphans.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Get list of orphans

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,7 +26,7 @@ jobs:
           github-token: "${{ secrets.GH_TOKEN_BOT_EVE }}"
 
       - name: Label autoapproved
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |

--- a/.github/workflows/bounty-program-commands.yml
+++ b/.github/workflows/bounty-program-commands.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: ❌ @${{github.actor}} made an unauthorized attempt to use a Bounty Program's command
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ACTOR: ${{ github.actor }}
         with:
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add label `bounty`
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove label `bounty`
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/cancel-event.yml
+++ b/.github/workflows/cancel-event.yml
@@ -4,7 +4,8 @@ on:
   issues:
     types:
       - closed
-
+permissions:
+  issues: write # needs write permissions to be able to add a comment to the issue when event was cancelled and to read the issue details
 jobs:
 
   cancel_event:
@@ -16,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -24,7 +27,7 @@ jobs:
         run: npm install
         working-directory: ./.github/workflows/create-event-helpers
       - name: Remove Google Calendar entry
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.04
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_CLOSED_AT: ${{ github.event.issue.closed_at }}

--- a/.github/workflows/cancel-event.yml
+++ b/.github/workflows/cancel-event.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm install
         working-directory: ./.github/workflows/create-event-helpers
       - name: Remove Google Calendar entry
-        uses: actions/github-script@v4
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.04
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_CLOSED_AT: ${{ github.event.issue.closed_at }}

--- a/.github/workflows/cancel-event.yml
+++ b/.github/workflows/cancel-event.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           cache-dependency-path: '**/package-lock.json'
       - name: Install deps

--- a/.github/workflows/create-event-ad-hoc.yml
+++ b/.github/workflows/create-event-ad-hoc.yml
@@ -18,7 +18,7 @@ on:
       meeting_banner: 
         description: 'Meeting banner(image) URL'
         required: false
-
+permissions: {}  # write permissions are defined in the create-event-workflow-reusable.yml workflow
 jobs:
 
   setup-ad-hoc:

--- a/.github/workflows/create-event-community-meeting.yml
+++ b/.github/workflows/create-event-community-meeting.yml
@@ -12,7 +12,7 @@ on:
       meeting_banner:
         description: 'Meeting banner(image) URL'
         required: false
-
+permissions: {}  # write permissions are defined in the create-event-workflow-reusable.yml workflow
 jobs:
   setup-community-meeting:
     uses: ./.github/workflows/create-event-workflow-reusable.yml

--- a/.github/workflows/create-event-lets-talk-about.yml
+++ b/.github/workflows/create-event-lets-talk-about.yml
@@ -16,6 +16,9 @@ on:
       meeting_banner:
         description: 'Meeting banner(image) URL'
         required: false
+
+permissions: {}  # write permissions are defined in the create-event-workflow-reusable.yml workflow
+
 jobs:
   setup-lets-talk-about-contrib-stream:
     uses: ./.github/workflows/create-event-workflow-reusable.yml

--- a/.github/workflows/create-event-spec-3-0.yml
+++ b/.github/workflows/create-event-spec-3-0.yml
@@ -12,7 +12,7 @@ on:
       meeting_banner:
         description: 'Meeting banner(image) URL'
         required: false
-
+permissions: {}  # write permissions are defined in the create-event-workflow-reusable.yml workflow
 jobs:
 
   setup-spec-3-0-meeting:

--- a/.github/workflows/create-event-spec-3-docs.yml
+++ b/.github/workflows/create-event-spec-3-docs.yml
@@ -12,6 +12,8 @@ on:
       meeting_banner:
         description: 'Meeting banner(image) URL'
         required: false
+        
+permissions: {}  # write permissions are defined in the create-event-workflow-reusable.yml workflow
 
 jobs:
   setup-spec-3-docs-meeting:

--- a/.github/workflows/create-event-thinking-out-loud.yml
+++ b/.github/workflows/create-event-thinking-out-loud.yml
@@ -19,6 +19,8 @@ on:
         description: 'Meeting banner(image) URL'
         required: false
 
+permissions: {}  # write permissions are defined in the create-event-workflow-reusable.yml workflow
+
 jobs:
   setup-thinking-out-loud:
     uses: ./.github/workflows/create-event-workflow-reusable.yml

--- a/.github/workflows/create-event-workflow-reusable.yml
+++ b/.github/workflows/create-event-workflow-reusable.yml
@@ -73,6 +73,9 @@ on:
 
 jobs:
   setup-meeting:
+    permissions:
+      contents: read
+      issues: write
     env:
       ZOOM_ACCOUNT_ID: ${{ secrets.ZOOM_ACCOUNT_ID }}
       ZOOM_TOKEN: ${{ secrets.ZOOM_TOKEN }}
@@ -85,15 +88,18 @@ jobs:
     steps:
       - name: Validate inputs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TIME: ${{ inputs.time }}
+          DATE: ${{ inputs.date }}
         with:
           script: |
-            const time = '${{inputs.time}}'
+            const time = '${TIME}';
             const [HH, MM] = time.split(':')
             if(Number(HH) > 23 || Number(HH) < 0 || !(Number(MM) === 0 || Number(MM) === 30)){
               core.setFailed(`${time} is an invalid input. Time should be in UTC time zone in "HH:MM"(MM can be 00 or 30), like: 08:30 or 16:00. No PM or AM versions.`);
             }
             // Validate if the event is in the future
-            const eventDate = new Date('${{ inputs.date }}T${{ inputs.time }}:00Z');
+            const eventDate = new Date(`${DATE}T${TIME}:00Z`);
             const currentDate = new Date();
             if (eventDate <= currentDate) {
               let errorMessage = `The event cannot be scheduled in the past. You attempted to schedule the event on ${eventDate.toLocaleString()}, but the current date and time is ${currentDate.toLocaleString()}. Please specify a future date and time for the event.`;
@@ -101,6 +107,8 @@ jobs:
             }
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -115,11 +123,14 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: zoom
         env:
-          MEETING_NAME: ${{ inputs.meeting_name }}
+          DATE: ${{ inputs.date }}
+          TIME: ${{ inputs.time }}
+          HOST: ${{ inputs.host }}
+          ALTERNATIVE_HOST: ${{ inputs.alternative_host }}
         with:
           script: |
             const setupZoom = require('./.github/workflows/create-event-helpers/zoom/index.js');
-            setupZoom('${{ inputs.date }}', '${{ inputs.time }}', '${{ inputs.host }}', '${{ inputs.alternative_host }}');
+            setupZoom('${DATE}', '${TIME}', '${HOST}', '${ALTERNATIVE_HOST}');
       - name: Create issue with meeting details
         uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # version v2 https://github.com/JasonEtco/create-an-issue/tree/v2/
         id: create-issue
@@ -136,17 +147,21 @@ jobs:
         with:
           filename: ${{ inputs.issue_template_path }}
       - name: Create Google Calendar entry
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.04
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           MEETING_NAME: ${{ inputs.meeting_name }}
           MEETING_NAME_SUFFIX: ${{ inputs.meeting_name_suffix }}
           MEETING_DESC: ${{ inputs.meeting_desc }}
           MEETING_BANNER: ${{ inputs.meeting_banner }}
           GUEST: ${{ inputs.guest }}
+          MEETING_URL: ${{ steps.zoom.outputs.meetingUrl }}
+          DATE: ${{ inputs.date }}
+          TIME: ${{ inputs.time }}
+          ISSUE_NUMBER: ${{ steps.create-issue.outputs.number }}
         with:
           script: |
             const { addEvent } = require('./.github/workflows/create-event-helpers/calendar/index.js');
-            addEvent('${{ steps.zoom.outputs.meetingUrl }}', '${{ inputs.date }}', '${{ inputs.time }}', '${{ steps.create-issue.outputs.number }}');
+            addEvent('$MEETING_URL', '$DATE', '$TIME', '$ISSUE_NUMBER');
       - name: Publish information about meeting to Twitter
         uses: m1ner79/Github-Twittction@6269f2c6ace92b904304ca33a18aebd5e5ae9ee7 # version v1.0.1 https://github.com/m1ner79/Github-Twittction/tree/v1.0.1/
         with:

--- a/.github/workflows/create-event-workflow-reusable.yml
+++ b/.github/workflows/create-event-workflow-reusable.yml
@@ -100,9 +100,9 @@ jobs:
               core.setFailed(errorMessage);
             }
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/create-event-workflow-reusable.yml
+++ b/.github/workflows/create-event-workflow-reusable.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate inputs
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const time = '${{inputs.time}}'
@@ -112,7 +112,7 @@ jobs:
         working-directory: ./.github/workflows/create-event-helpers
       - if: inputs.create_zoom == true
         name: Create zoom meeting
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: zoom
         env:
           MEETING_NAME: ${{ inputs.meeting_name }}
@@ -136,7 +136,7 @@ jobs:
         with:
           filename: ${{ inputs.issue_template_path }}
       - name: Create Google Calendar entry
-        uses: actions/github-script@v4
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.04
         env:
           MEETING_NAME: ${{ inputs.meeting_name }}
           MEETING_NAME_SUFFIX: ${{ inputs.meeting_name_suffix }}

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write                # To comment on Pull requests
     steps:
       - name: Add comment to PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ACTOR: ${{ github.actor }}
         with:
@@ -53,7 +53,7 @@ jobs:
       issues: write                       # To comment on Issues
     steps:
       - name: Add comment to Issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ACTOR: ${{ github.actor }}
         with:

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -45,7 +45,7 @@ jobs:
         shell: bash
       - if: steps.should_run.outputs.shouldrun == 'true' 
         name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - if: steps.should_run.outputs.shouldrun == 'true' 
@@ -62,7 +62,7 @@ jobs:
         id: lockversion
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "${{ steps.lockversion.outputs.version }}"
       - if: steps.lockversion.outputs.version == '18' && matrix.os == 'windows-latest'

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -1,13 +1,17 @@
 name: Maintainer Management Workflow
 
-on:
-  pull_request_target:
+on: # zizmor: ignore[dangerous-triggers] -- intentional, gated by merged==true, reads MAINTAINERS.yaml as data only
+  pull_request_target: 
     types: [closed]
     paths: 
       - 'MAINTAINERS.yaml'
 
+permissions: {}
+
 jobs:
   detect_maintainer_changes:
+    permissions: 
+      contents: read # needs read permissions to be able to read the content of the MAINTAINERS.yaml file
     if: github.event.pull_request.merged 
     runs-on: ubuntu-latest
     steps: 
@@ -16,6 +20,7 @@ jobs:
         with:
           ref: master
           path: community-main
+          persist-credentials: false
       - name: List of directory
         run: ls -la
       - name: Checkout one commit before last one
@@ -24,6 +29,7 @@ jobs:
           fetch-depth: 2
           ref: master
           path: community
+          persist-credentials: false
       - name: List of directory 
         run: ls -la
       - run: cd community && git checkout HEAD^
@@ -72,12 +78,16 @@ jobs:
             core.info(fs.realpathSync('./community/MAINTAINERS.yaml'));
 
       - name: Debug newMaintainers output
+        env:
+          NEW_MAINTAINERS: ${{ steps.compare-files.outputs.newMaintainers }}
         run: |
-          echo "newMaintainers = ${{ steps.compare-files.outputs.newMaintainers }}"
+          echo "newMaintainers = $NEW_MAINTAINERS"
 
       - name: Debug removedMaintainers output
+        env:
+          REMOVED_MAINTAINERS: ${{ steps.compare-files.outputs.removedMaintainers }}
         run: |
-          echo "removedMaintainers = ${{ steps.compare-files.outputs.removedMaintainers }}"
+          echo "removedMaintainers = $REMOVED_MAINTAINERS"
 
     outputs:
       newMaintainers: ${{ steps.compare-files.outputs.newMaintainers }}
@@ -85,16 +95,19 @@ jobs:
       removedTscMembers: ${{ steps.compare-files.outputs.removedTscMembers }}
 
   add_maintainer:
+    permissions: {} # uses GH_TOKEN_ORG_ADMIN with admin permissions to the organization, so no need to set permissions at the job level
     needs: detect_maintainer_changes
     if: needs.detect_maintainer_changes.outputs.newMaintainers != ''
     runs-on: ubuntu-latest
     steps:
       - name: Invite new maintainers to the organization
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          NEW_MAINTAINERS: ${{ needs.detect_maintainer_changes.outputs.newMaintainers }}
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
-            const newMaintainers = '${{ needs.detect_maintainer_changes.outputs.newMaintainers }}'.split(',');
+            const newMaintainers = process.env.NEW_MAINTAINERS.split(',');
             for (const maintainer of newMaintainers) {
               try {
                 await github.request('PUT /orgs/{org}/memberships/{username}', {
@@ -108,10 +121,12 @@ jobs:
 
       - name: Add new maintainers to the team
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          NEW_MAINTAINERS: ${{ needs.detect_maintainer_changes.outputs.newMaintainers }}
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
-            const newMaintainers = '${{ needs.detect_maintainer_changes.outputs.newMaintainers }}'.split(',');
+            const newMaintainers = process.env.NEW_MAINTAINERS.split(',');
             for (const maintainer of newMaintainers) {
               try {
                 await github.request('PUT /orgs/{org}/teams/{team_slug}/memberships/{username}', {
@@ -128,16 +143,20 @@ jobs:
       newMaintainers: ${{needs.detect_maintainer_changes.outputs.newMaintainers }}
 
   display_message:
+    permissions: 
+      pull_requests: write # posts comment on PR with new maintainers welcome message and information about becoming TSC member
     needs: add_maintainer
     if: needs.add_maintainer.outputs.newMaintainers != ''
     runs-on: ubuntu-latest
     steps:
       - name: Display welcome message for new maintainers
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          NEW_MAINTAINERS: ${{ needs.add_maintainer.outputs.newMaintainers }}
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
-            const newMaintainers = "${{ needs.add_maintainer.outputs.newMaintainers }}".split(",");
+            const newMaintainers = process.env.NEW_MAINTAINERS.split(",");
             console.log(`New maintainers: ${newMaintainers}`);
             const welcomeMessage = newMaintainers.map((maintainer) => `@${maintainer.trim().replace(/^@/, '')} We invited you to join the AsyncAPI organization, and you are added to the team that lists all Maintainers.\n
             
@@ -154,16 +173,19 @@ jobs:
             return github.rest.issues.createComment({ owner, repo, issue_number, body: welcomeMessage });
 
   remove_maintainer:
+    permissions: {} # uses GH_TOKEN_ORG_ADMIN with admin permissions to the organization, so no need to set permissions at the job level
     needs: detect_maintainer_changes
     if: needs.detect_maintainer_changes.outputs.removedMaintainers != ''
     runs-on: ubuntu-latest
     steps:
       - name: Remove maintainers from the organization
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REMOVED_MAINTAINERS: ${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
-            const removedMaintainers = '${{ needs.detect_maintainer_changes.outputs.removedMaintainers }}'.split(',');
+            const removedMaintainers = process.env.REMOVED_MAINTAINERS.split(',');
             for (const maintainer of removedMaintainers) {
               try {
                 await github.request('DELETE /orgs/{org}/memberships/{username}', {
@@ -185,17 +207,20 @@ jobs:
       removedTscMembers: ${{ needs.detect_maintainer_changes.outputs.removedTscMembers }}
 
   remove_maintainer_goodbye:
+    permissions: 
+      issues: write # needs write permissions to be able to add a comment to the issue when maintainer is removed and to read the issue details
     needs: remove_maintainer
     if: needs.remove_maintainer.outputs.removedMaintainers != ''
     runs-on: ubuntu-latest
     steps:
       - name: Display goodbye message to removed maintainers
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REMOVED_MAINTAINERS: ${{ needs.remove_maintainer.outputs.removedMaintainers }}
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
-              const removedMaintainers = "${{ needs.remove_maintainer.outputs.removedMaintainers }}".split(",");
-
+              const removedMaintainers = process.env.REMOVED_MAINTAINERS.split(",");
               // Goodbye message to removed maintainers
               const combinedMessages = removedMaintainers.map((maintainer) => {
                 return `@${maintainer.trim().replace(/^@/, '')} We would like to express our gratitude for your contributions as a maintainer of AsyncAPI Initiative. Your efforts have been immensely valuable to us, and we truly appreciate your dedication. Thank you once again, and we wish you all the best in your future endeavors!\n\n`;
@@ -208,6 +233,7 @@ jobs:
               }
 
   notify_slack_on_failure:
+    permissions: {} # no permissions needed as this job only sends a notification to Slack in case of failure in any of the previous jobs, and it is gated by always() condition
     if: always() && (needs.detect_maintainer_changes.result == 'failure' || needs.add_maintainer.result == 'failure' || needs.display_message.result == 'failure' || needs.remove_maintainer.result == 'failure' || needs.remove_maintainer_goodbye.result == 'failure')
     needs: [detect_maintainer_changes, add_maintainer, display_message, remove_maintainer, remove_maintainer_goodbye]
     runs-on: ubuntu-latest

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm install js-yaml@4.1.0
       - name: Compare files
         id: compare-files
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require("fs");
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Invite new maintainers to the organization
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
@@ -107,7 +107,7 @@ jobs:
             }
 
       - name: Add new maintainers to the team
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Display welcome message for new maintainers
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove maintainers from the organization
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Display goodbye message to removed maintainers
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |

--- a/.github/workflows/maintainer_management.yml
+++ b/.github/workflows/maintainer_management.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - name: Checkout main branch 
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           path: community-main
       - name: List of directory
         run: ls -la
       - name: Checkout one commit before last one
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
           ref: master
@@ -213,7 +213,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Report workflow run status to Slack
-      uses: rtCamp/action-slack-notify@v2
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
       env:
         SLACK_WEBHOOK: ${{secrets.SLACK_CI_FAIL_NOTIFY}}
         SLACK_TITLE: 🚨 Maintainer Management Workflow failed 🚨

--- a/.github/workflows/maintainers-tsc-changes-verification.yaml
+++ b/.github/workflows/maintainers-tsc-changes-verification.yaml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           path: community-main
 
       - name: Checkout PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}

--- a/.github/workflows/maintainers-tsc-changes-verification.yaml
+++ b/.github/workflows/maintainers-tsc-changes-verification.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Verify changes in MAINTAINERS.yaml
         id: verify-changes
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment and close the PR if there are any critical changes done by human
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
@@ -157,7 +157,7 @@ jobs:
     steps:
       - name: Comment on PR if TSC member is removed by asyncapi-bot
         if: steps.verify-changes-if-tsc-if-maintainers.outputs.removedTscMembers != ''
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |

--- a/.github/workflows/manual-netlify-preview.yml
+++ b/.github/workflows/manual-netlify-preview.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout community PR
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout website repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: asyncapi/website
           path: website
@@ -29,7 +29,7 @@ jobs:
           rm website/markdown/docs/community/README.md
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
 

--- a/.github/workflows/microgrant-program-commands.yml
+++ b/.github/workflows/microgrant-program-commands.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: ❌ @${{github.actor}} made an unauthorized attempt to use a Microgrant Program's command
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ACTOR: ${{ github.actor }}
         with:
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add label `microgrant`
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove label `microgrant`
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/notify-tsc-members-mention.yml
+++ b/.github/workflows/notify-tsc-members-mention.yml
@@ -34,11 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -83,11 +83,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -132,11 +132,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -181,11 +181,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -230,11 +230,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -279,11 +279,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: 'npm'

--- a/.github/workflows/notify-tsc-members-mention.yml
+++ b/.github/workflows/notify-tsc-members-mention.yml
@@ -66,7 +66,7 @@ jobs:
         run: npm install
         working-directory: ./.github/workflows/scripts/kit
       - name: Send email with Kit.com
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           KIT_API_KEY: ${{ secrets.KIT_API_KEY }}
           KIT_TSC_TAG_ID: ${{ secrets.KIT_TSC_TAG_ID }}
@@ -115,7 +115,7 @@ jobs:
         run: npm install
         working-directory: ./.github/workflows/scripts/kit
       - name: Send email with Kit.com
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           KIT_API_KEY: ${{ secrets.KIT_API_KEY }}
           KIT_TSC_TAG_ID: ${{ secrets.KIT_TSC_TAG_ID }}
@@ -164,7 +164,7 @@ jobs:
         run: npm install
         working-directory: ./.github/workflows/scripts/kit
       - name: Send email with Kit.com
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           KIT_API_KEY: ${{ secrets.KIT_API_KEY }}
           KIT_TSC_TAG_ID: ${{ secrets.KIT_TSC_TAG_ID }}
@@ -213,7 +213,7 @@ jobs:
         run: npm install
         working-directory: ./.github/workflows/scripts/kit
       - name: Send email with Kit.com
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           KIT_API_KEY: ${{ secrets.KIT_API_KEY }}
           KIT_TSC_TAG_ID: ${{ secrets.KIT_TSC_TAG_ID }}
@@ -262,7 +262,7 @@ jobs:
         run: npm install
         working-directory: ./.github/workflows/scripts/kit
       - name: Send email with Kit.com
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           KIT_API_KEY: ${{ secrets.KIT_API_KEY }}
           KIT_TSC_TAG_ID: ${{ secrets.KIT_TSC_TAG_ID }}
@@ -311,7 +311,7 @@ jobs:
         run: npm install
         working-directory: ./.github/workflows/scripts/kit
       - name: Send email with Kit.com
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           KIT_API_KEY: ${{ secrets.KIT_API_KEY }}
           KIT_TSC_TAG_ID: ${{ secrets.KIT_TSC_TAG_ID }}

--- a/.github/workflows/please-take-a-look-command.yml
+++ b/.github/workflows/please-take-a-look-command.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for Please Take a Look Command
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |

--- a/.github/workflows/release-announcements.yml
+++ b/.github/workflows/release-announcements.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Convert markdown to slack markdown for issue
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Get version of last and previous release

--- a/.github/workflows/release-announcements.yml
+++ b/.github/workflows/release-announcements.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Get version of last and previous release
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: versions
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/send-events-newsletter.yml
+++ b/.github/workflows/send-events-newsletter.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm install
         working-directory: ./.github/workflows/create-event-helpers
       - name: Send email with Kit.com
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           CALENDAR_ID: ${{ secrets.CALENDAR_ID }}
           CALENDAR_SERVICE_ACCOUNT: ${{ secrets.CALENDAR_SERVICE_ACCOUNT }}

--- a/.github/workflows/send-events-newsletter.yml
+++ b/.github/workflows/send-events-newsletter.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: 'npm'

--- a/.github/workflows/slack-integration.yml
+++ b/.github/workflows/slack-integration.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3
         with:

--- a/.github/workflows/tsc_management.yml
+++ b/.github/workflows/tsc_management.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           path: community-main
 
       - name: Checkout one commit before last one
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
           ref: master
@@ -200,7 +200,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Add Former TSC members to Emeritus.yaml and print
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -274,7 +274,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Report workflow run status to Slack
-      uses: rtCamp/action-slack-notify@v2
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
       env:
         SLACK_WEBHOOK: ${{secrets.SLACK_CI_FAIL_NOTIFY}}
         SLACK_TITLE: 🚨 TSC Management Workflow failed 🚨

--- a/.github/workflows/tsc_management.yml
+++ b/.github/workflows/tsc_management.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Compare files
         id: compare-files
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add new TSC members to the team
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
@@ -113,7 +113,7 @@ jobs:
     steps:
       - name: Filter GitHub users with updatedValue
         id: filter_users
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
@@ -123,7 +123,7 @@ jobs:
 
       - name: Display welcome message to new TSC members
         if: steps.filter_users.outputs.filteredUsers != '[]'
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove TSC members from the team
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN_ORG_ADMIN }}
           script: |
@@ -174,7 +174,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Display goodbye message to removed TSC members
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
@@ -203,7 +203,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Add Former TSC members to Emeritus.yaml and print
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/twitter-recurring-ideas.yml
+++ b/.github/workflows/twitter-recurring-ideas.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup node to execute script
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '14'
       - name: Create another copy of the tweet

--- a/.github/workflows/twitter-recurring-slack.yml
+++ b/.github/workflows/twitter-recurring-slack.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup node to execute script
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '14'
       - name: Create another copy of the tweet

--- a/.github/workflows/update-docs-in-website.yml
+++ b/.github/workflows/update-docs-in-website.yml
@@ -16,11 +16,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Checkout Current repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: community
       - name: Checkout Another repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: asyncapi/website
           path: website

--- a/.github/workflows/update-docs-in-website.yml
+++ b/.github/workflows/update-docs-in-website.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           git checkout -b update-community-docs-${{ github.sha }}
       - name: Update edit-page-config.json
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.04
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
                 const fs = require('fs').promises;

--- a/.github/workflows/update-docs-in-website.yml
+++ b/.github/workflows/update-docs-in-website.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           git checkout -b update-community-docs-${{ github.sha }}
       - name: Update edit-page-config.json
-        uses: actions/github-script@v4
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.04
         with:
           script: |
                 const fs = require('fs').promises;

--- a/.github/workflows/update-docs-on-docs-commits.yml
+++ b/.github/workflows/update-docs-on-docs-commits.yml
@@ -21,12 +21,12 @@ jobs:
     if: startsWith(github.event.commits[0].message, 'docs:')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check package-lock version
         uses: asyncapi/.github/.github/actions/get-node-version-from-package-lock@master
         id: lockversion
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "${{ steps.lockversion.outputs.version }}"
           cache: 'npm'

--- a/.github/workflows/update-maintainers.yaml
+++ b/.github/workflows/update-maintainers.yaml
@@ -89,7 +89,7 @@ jobs:
         run: npm install js-yaml@4 --no-save
 
       - name: Run script updating MAINTAINERS.yaml
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_TOKEN: ${{ github.token }}
           MAINTAINERS_FILE_PATH: "${{ github.workspace }}/MAINTAINERS.yaml"

--- a/.github/workflows/update-maintainers.yaml
+++ b/.github/workflows/update-maintainers.yaml
@@ -38,7 +38,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # If an action pushes code using the repository’s GITHUB_TOKEN, a pull request workflow will not run.
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Get Pull Request Details
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_TOKEN || github.token }}
           previews: 'merge-info-preview' # https://docs.github.com/en/graphql/overview/schema-previews#merge-info-preview-more-detailed-information-about-a-pull-requests-merge-state-preview
@@ -61,7 +61,7 @@ jobs:
             }
       - name: Update the Pull Request
         if: steps.pr.outputs.updateable == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_DETAILS: ${{ steps.pr.outputs.result }}
         with:

--- a/.github/workflows/update-website-ambassador.yml
+++ b/.github/workflows/update-website-ambassador.yml
@@ -16,11 +16,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Checkout Current repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: community
       - name: Checkout Another repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: asyncapi/website
           path: website

--- a/.github/workflows/update-website-board-governance.yml
+++ b/.github/workflows/update-website-board-governance.yml
@@ -18,19 +18,19 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Checkout Current repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: community
 
       - name: Checkout Another repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: asyncapi/website
           path: website
           token: ${{ env.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 18
 

--- a/.github/workflows/update-website-tsc.yml
+++ b/.github/workflows/update-website-tsc.yml
@@ -16,11 +16,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Checkout Current repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: community
       - name: Checkout Another repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: asyncapi/website
           path: website
@@ -61,7 +61,7 @@ jobs:
           gh pr create --title "docs(community): update latest maintainers list" --body "Updated Maintainers list is available and this PR introduces changes with latest information about Maintainers" --head "update-tscmembers-${{ github.sha }}"
       - name: Report workflow run status to Slack
         if: failure() # Only, on failure, send a message on the slack channel
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_CI_FAIL_NOTIFY }}
           SLACK_TITLE: 🚨 Update maintainers list action failed 🚨

--- a/.github/workflows/validate-maintainers.yml
+++ b/.github/workflows/validate-maintainers.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'MAINTAINERS.yaml'
 
+permissions: {}
+
 jobs:
   # Make sure that changes in the MAINTAINERS.yaml file do not break the schema
   # Until we have MAINTAINERS.yaml updates automated, we need to ensure we are not breaking things
@@ -20,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: npm install js-yaml@4.1.0
       - name: Validate list with schema
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.04
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const Ajv = require("ajv");
@@ -53,7 +55,7 @@ jobs:
       - name: Install dependencies
         run: npm install js-yaml@4.1.0
       - name: Calculate
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.04
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/validate-maintainers.yml
+++ b/.github/workflows/validate-maintainers.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: npm install js-yaml@4.1.0
       - name: Validate list with schema
-        uses: actions/github-script@v4
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.04
         with:
           script: |
             const Ajv = require("ajv");
@@ -53,7 +53,7 @@ jobs:
       - name: Install dependencies
         run: npm install js-yaml@4.1.0
       - name: Calculate
-        uses: actions/github-script@v4
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.04
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/validate-maintainers.yml
+++ b/.github/workflows/validate-maintainers.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: npm install ajv@6.12.6
       - name: Install dependencies
         run: npm install js-yaml@4.1.0
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
         run: npm install js-yaml@4.1.0
       - name: Calculate

--- a/.github/workflows/vote-notify.yml
+++ b/.github/workflows/vote-notify.yml
@@ -39,7 +39,7 @@ jobs:
 
       # List all the open issues with the label "vote open"
       - name: List current open issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: list
         with:
           script: |
@@ -78,7 +78,7 @@ jobs:
         shell: bash
 
       - name: Notify TSC Members
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: notify
         env:
           MAILJET_API_KEY: ${{ secrets.MAILJET_PUBLIC_KEY}}

--- a/.github/workflows/vote-notify.yml
+++ b/.github/workflows/vote-notify.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # To store the state of the votes and the last time the TSC members were notified
       # The format of the file is:
@@ -163,7 +163,7 @@ jobs:
       # Always alert on any failures, regardless of method
       - name: Notify about failing Slack DMs
         if: ${{ env.FAILED_IDS }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_CI_FAIL_NOTIFY }}
           SLACK_TITLE: 🚨 Vote notifications couldn’t be sent 🚨

--- a/.github/workflows/vote-tracker.yml
+++ b/.github/workflows/vote-tracker.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Installing Module
         run: npm install js-yaml@4.1.0 --no-save

--- a/.github/workflows/vote-tracker.yml
+++ b/.github/workflows/vote-tracker.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run GitHub Script
         id: vote_tracker
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const script = require('./.github/scripts/vote_tracker/index.js');

--- a/.github/workflows/vote-verifcation.yml
+++ b/.github/workflows/vote-verifcation.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Verify the person
         id: verify_member
         uses: ./.github/actions/verifyTSCMember

--- a/.github/workflows/vote-verifcation.yml
+++ b/.github/workflows/vote-verifcation.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Checking the person authenticity.
         if: (github.event.comment.body == '/vote') || (github.event.comment.body == '/cancel-vote')
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
           ACTOR: ${{ github.actor }}

--- a/.github/workflows/welcome-first-time-contrib.yml
+++ b/.github/workflows/welcome-first-time-contrib.yml
@@ -25,7 +25,7 @@ jobs:
       issues: write             # Required to post welcome message on issues
       pull-requests: write      # Required to post welcome message on pull requests
     steps:
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ github.token }}
         script: |


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**


**Security hardening of workflow files:**
- Added `permissions: {}` at workflow level with minimal per-job overrides
- Moved all `${{ }}` template expressions into `env:` blocks to prevent shell/script injection
- Pinned all action versions to full commit SHAs
- Added `persist-credentials: false` on checkouts

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated all GitHub Actions workflows to use pinned versions of `actions/github-script` (v9.0.0) instead of floating version references across automation workflows, enhancing stability and security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/community/pull/3559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->