### PR TITLE
docs: fix AMP disbursement link

### DIFF
--- a/docs/maintainership-guide/amp-evaluation-process.md
+++ b/docs/maintainership-guide/amp-evaluation-process.md
@@ -51,4 +51,4 @@ _Note: If one or more contributors do not pass, their portion is redistributed a
 
 Once your evaluation is marked as “pass,” you will be eligible to request your stipend via the [AsyncAPI Mentorship Open Collective](https://opencollective.com/asyncapi/projects/asyncapi-mentorship) page.
 
-Please allow **a few business days** for your payment to be processed after submission. If you’re unsure how to submit your expense, [refer to this guide](./amp-payments-disbursement.md).
+Please allow **a few business days** for your payment to be processed after submission. If you’re unsure how to submit your expense, [refer to this guide](https://www.asyncapi.com/docs/community/maintainership-guide/amp-payments-disbursement).

--- a/docs/maintainership-guide/amp-evaluation-process.md
+++ b/docs/maintainership-guide/amp-evaluation-process.md
@@ -51,4 +51,4 @@ _Note: If one or more contributors do not pass, their portion is redistributed a
 
 Once your evaluation is marked as “pass,” you will be eligible to request your stipend via the [AsyncAPI Mentorship Open Collective](https://opencollective.com/asyncapi/projects/asyncapi-mentorship) page.
 
-Please allow **a few business days** for your payment to be processed after submission. If you’re unsure how to submit your expense, [refer to this guide](../stipend-and-payments/disbursement).
+Please allow **a few business days** for your payment to be processed after submission. If you’re unsure how to submit your expense, [refer to this guide](./amp-payments-disbursement.md).


### PR DESCRIPTION
## Summary
- replace the removed stipend disbursement path with the current AMP payment disbursement guide
- keep the change limited to the broken link reported in #3617

## Validation
- confirmed the relative target exists
- `git diff --check`

Fixes #3617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the stipend disbursement guide link in the payment section to reference the correct document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->